### PR TITLE
refactor: Upgrade to Fable 5.0.0-rc.5, modernize BEAM build

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "5.0.0-rc.3",
+      "version": "5.0.0-rc.5",
       "commands": [
         "fable"
       ],
       "rollForward": false
     },
     "fantomas": {
-      "version": "6.2.3",
+      "version": "7.0.5",
       "commands": [
         "fantomas"
       ],
@@ -24,7 +24,7 @@
       "rollForward": false
     },
     "paket": {
-      "version": "8.0.0",
+      "version": "10.3.1",
       "commands": [
         "paket"
       ],

--- a/.gitignore
+++ b/.gitignore
@@ -138,9 +138,8 @@ obj/
 .vscode/
 Fable.Giraffe.sln.DotSettings.user
 
-# BEAM build output (Fable-generated Erlang apps and rebar3 build)
-apps/
-_build/
-rebar.lock
+# BEAM build output lives under build/ (already gitignored)
 
 .fake
+.claude/worktrees/
+erl_crash.dump

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ type HttpHandler = HttpFunc -> HttpFunc
 ### Build System
 
 - `Justfile` - Build targets (replaces the old FAKE-based Build.fs)
-- Uses Fable 5.0.0-alpha.23 for F# to Python compilation
+- Uses Fable 5.0.0-rc.5 for F# to Python compilation
 - Uses uv for Python dependency management
 
 ### Compilation Flow

--- a/FABLE_V5_BUGS.md
+++ b/FABLE_V5_BUGS.md
@@ -1,104 +1,60 @@
 # Fable v5 Python Backend Bugs
 
-Bugs discovered while porting Fable.Giraffe to Fable 5.0.0-alpha.23. These should be investigated and fixed in the Fable compiler or fable-library.
+Bugs discovered while porting Fable.Giraffe to Fable v5. Updated for Fable 5.0.0-rc.5.
 
-## Bug 1: Missing `await` in async functions returning Task from if/match branches
+## Fixed in 5.0.0-rc.5
+
+### Missing `await` in if/match branches (statements)
+
+Previously, when an F# function returned `Task<T>` by passing through if/match branches without a `task {}` CE, Fable generated `async def` but omitted `await` on the returned coroutines. This is now fixed — if/match statements correctly generate `await` on both branches.
+
+### `match value with :? Type as x` reassigns outer variable in closure
+
+Previously, using `match value with | :? SomeType as x -> ...` inside a closure would reassign the outer variable in the compiled Python, triggering `UnboundLocalError`. This appears to be fixed (no longer reproducible).
+
+## Still broken in 5.0.0-rc.5
+
+### Missing `await` in ternary expressions
 
 **Severity:** Critical
 **Affects:** Python backend
 
-When an F# function returns `Task<T>` by passing through another task from if/match branches (without using a `task {}` CE), Fable generates `async def` but omits `await` on the returned coroutines.
+When Fable compiles a simple two-branch `match` on a boolean into a Python ternary expression, only one branch gets `await`. This happens when the function returns `Task<T>` directly (pass-through) without a `task {}` CE.
 
 **F# input:**
 
 ```fsharp
-type HttpFuncResult = Task<HttpContext option>
-type HttpFunc = HttpContext -> HttpFuncResult
-
-let skipPipeline () : HttpFuncResult = Task.FromResult None
-
-let httpVerb (validate: string -> bool) =
-    fun (next: HttpFunc) (ctx: HttpContext) ->
-        if validate ctx.Request.Method then
-            next ctx
-        else
-            skipPipeline ()
+let compose (handler1: HttpHandler) (handler2: HttpHandler) : HttpHandler =
+    fun (final: HttpFunc) ->
+        let func = final |> handler2 |> handler1
+        fun (ctx: HttpContext) ->
+            match ctx.Response.HasStarted with
+            | true -> final ctx
+            | false -> func ctx
 ```
 
 **Generated Python (incorrect):**
 
 ```python
-async def httpVerb(validate, next_1, ctx):
-    if validate(get_method(ctx)):
-        return next_1(ctx)        # BUG: returns coroutine object, not result
-    else:
-        return skipPipeline()     # BUG: same issue
+async def _arrow(ctx):
+    return await final(ctx) if has_started(ctx) else func(ctx)  # BUG: missing await on else branch
 ```
 
 **Expected Python:**
 
 ```python
-async def httpVerb(validate, next_1, ctx):
-    if validate(get_method(ctx)):
-        return await next_1(ctx)   # Should await
-    else:
-        return await skipPipeline() # Should await
+async def _arrow(ctx):
+    return await final(ctx) if has_started(ctx) else await func(ctx)
 ```
 
-**Also affects ternary expressions:**
+**Pattern:** Two-branch `match` on a boolean that Fable optimizes into a ternary expression. Multi-statement if/match blocks (which Fable emits as full `if/else` statements) are now correctly awaited.
 
-```python
-# Generated:
-return await final(ctx) if condition else func(ctx)  # Only one branch gets await
-
-# Expected:
-return await final(ctx) if condition else await func(ctx)
-```
-
-**Pattern:** Functions that return `Task<T>` directly (pass-through) without `task {}` CE. Functions with statements before the return (e.g., `do_something(); next ctx`) correctly get `await`.
-
-**Workaround:** Wrap in explicit `task { return! ... }`:
+**Workaround:** Wrap in explicit `task { return! ... }` to force the task builder path, which avoids the raw ternary:
 
 ```fsharp
-fun (next: HttpFunc) (ctx: HttpContext) -> task {
-    if validate ctx.Request.Method then
-        return! next ctx
-    else
-        return! skipPipeline ()
+fun (ctx: HttpContext) -> task {
+    match ctx.Response.HasStarted with
+    | true -> return! final ctx
+    | false -> return! func ctx
 }
-```
-
-## Bug 2: `match value with :? Type as x` reassigns outer variable in closure
-
-**Severity:** Medium
-**Affects:** Python backend
-
-When using type test pattern `match value with | :? SomeType as x -> ...` inside a closure, the compiled Python reassigns the outer `value` variable instead of creating a new binding. This triggers Python's `UnboundLocalError` due to closure scoping rules.
-
-**F# input:**
-
-```fsharp
-let process (value: obj) =
-    task {
-        if key = "body" then
-            match value with
-            | :? (byte array) as bytes -> body.Add bytes
-            | _ -> failwith "expected byte array"
-    }
-```
-
-**Generated Python (incorrect):**
-
-```python
-def _arrow(value=value):
-    if key == "body":
-        if isinstance(value, Array):     # UnboundLocalError!
-            value = cast(Array, value)   # This assignment shadows outer 'value'
-```
-
-**Workaround:** Avoid `match ... with :? T as x` pattern. Use direct cast instead:
-
-```fsharp
-if key = "body" then
-    body.Add(value :?> byte array)
 ```

--- a/Justfile
+++ b/Justfile
@@ -7,21 +7,26 @@ app_path := "app"
 dev := "false"
 fable := if dev == "true" { "dotnet run --project ../Fable/src/Fable.Cli --" } else { "dotnet fable" }
 
+# BEAM compiler: use local Fable checkout when dev=true, otherwise use dotnet fable
+fable_beam := if dev == "true" { "dotnet run --project ../fable/main/src/Fable.Cli --" } else { "dotnet fable" }
 
 default:
     @just --list
 
 clean:
-    rm -rf {{build_path}} apps _build
+    rm -rf {{build_path}}
+
+clean-beam:
+    rm -rf {{build_path}}/apps {{build_path}}/_build
 
 build: clean
     mkdir -p {{build_path}}
     {{fable}} {{src_path}} --exclude Fable.Core --lang Python --outDir {{build_path}}/lib
 
-build-beam:
-    rm -rf apps _build
-    {{fable}} src/beam --exclude Fable.Core --lang beam --outDir apps/giraffe
-    rebar3 compile
+build-beam: clean-beam
+    {{fable_beam}} src/beam --exclude Fable.Core --lang beam --outDir {{build_path}}/apps/giraffe
+    cp rebar.config {{build_path}}/
+    cd {{build_path}} && rebar3 compile
 
 app: clean
     mkdir -p {{build_path}}
@@ -29,13 +34,9 @@ app: clean
     cd {{app_path}} && uv run uvicorn program:app --port 8080 --workers 1 --log-level error
 
 app-beam: build-beam
-    {{fable}} app/beam --exclude Fable.Core --lang beam --outDir apps/giraffe_app
-    rebar3 compile
-    erl \
-        -pa _build/default/lib/*/ebin \
-        -noshell \
-        -eval 'application:ensure_all_started(cowboy), program:start()' \
-        -eval 'receive stop -> ok end'
+    {{fable_beam}} app/beam --exclude Fable.Core --lang beam --outDir {{build_path}}/apps/giraffe_app
+    cd {{build_path}} && rebar3 compile
+    erl -pa {{build_path}}/_build/default/lib/*/ebin -noshell -eval "application:ensure_all_started(cowboy)" -eval "program:start()" -eval "receive stop -> ok end"
 
 test: build
     dotnet build {{test_path}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dependencies = [
     "fable-library==5.0.0rc3",
     "structlog>=24.4.0,<25",
-    "starlette>=0.38.5,<0.39",
+    "starlette>=1.0.0,<2",
     "pydantic>=2.0.0",
 ]
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,14 @@
-{deps, [
-    {cowboy, "2.12.0"}
-]}.
-
 {erl_opts, [no_debug_info, nowarn_unused_result]}.
+
+{deps, [
+    {cowboy, "2.12.0"},
+    jsx
+]}.
 
 {project_app_dirs, [
     "apps/giraffe", "apps/giraffe/fable_modules/*",
     "apps/giraffe_app", "apps/giraffe_app/fable_modules/*"
 ]}.
+
+%% NOTE: This config is copied into build/ at build time.
+%% Paths are relative to build/ where rebar3 runs.

--- a/src/beam/Fable.Giraffe.Beam.fsproj
+++ b/src/beam/Fable.Giraffe.Beam.fsproj
@@ -31,6 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="5.0.0-rc.1" />
-    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.5" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.14" />
+    <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.14" />
   </ItemGroup>
 </Project>

--- a/src/beam/HttpContext.fs
+++ b/src/beam/HttpContext.fs
@@ -112,18 +112,18 @@ type RequestHeaders(headers: ResizeArray<ResizeArray<string>>) =
 
 /// HTTP request backed by a Cowboy request object.
 type HttpRequest(req: Req) =
-    member x.Path: string option = CowboyReq.path req |> Some
+    member x.Path: string option = Fable.Beam.Cowboy.CowboyReq.path req |> Some
 
-    member x.Method: string = CowboyReq.method' req
+    member x.Method: string = Fable.Beam.Cowboy.CowboyReq.method' req
 
-    member x.Protocol: string = CowboyReq.scheme req
+    member x.Protocol: string = Fable.Beam.Cowboy.CowboyReq.scheme req
 
     member x.GetTypedHeaders() : RequestHeaders =
         // Convert Cowboy headers map to the expected format
         RequestHeaders(ResizeArray())
 
     member x.GetBodyAsync() = task {
-        let (_ok, body, _req2) = CowboyReq.readBody req
+        let (_ok, body, _req2) = Fable.Beam.Cowboy.CowboyReq.readBody req
         return body
     }
 

--- a/src/beam/HttpContext.fs
+++ b/src/beam/HttpContext.fs
@@ -112,18 +112,18 @@ type RequestHeaders(headers: ResizeArray<ResizeArray<string>>) =
 
 /// HTTP request backed by a Cowboy request object.
 type HttpRequest(req: Req) =
-    member x.Path: string option = Fable.Beam.Cowboy.CowboyReq.path req |> Some
+    member x.Path: string option = CowboyReq.path req |> Some
 
-    member x.Method: string = Fable.Beam.Cowboy.CowboyReq.method' req
+    member x.Method: string = CowboyReq.method' req
 
-    member x.Protocol: string = Fable.Beam.Cowboy.CowboyReq.scheme req
+    member x.Protocol: string = CowboyReq.scheme req
 
     member x.GetTypedHeaders() : RequestHeaders =
         // Convert Cowboy headers map to the expected format
         RequestHeaders(ResizeArray())
 
     member x.GetBodyAsync() = task {
-        let (_ok, body, _req2) = Fable.Beam.Cowboy.CowboyReq.readBody req
+        let (_ok, body, _req2) = CowboyReq.readBody req
         return body
     }
 

--- a/src/beam/Json.fs
+++ b/src/beam/Json.fs
@@ -2,27 +2,15 @@ module Fable.Giraffe.Json
 
 open Fable.Core
 
-/// Erlang JSON encoding using the built-in json module (OTP 27+)
-/// or thoas/jsx for earlier versions. We use Emit to call the
-/// Erlang json module directly.
+/// JSON encoding/decoding using jsx (pure Erlang JSON library).
 
-/// Use giraffe_json_encoder to avoid module name collision with OTP's json module.
-/// (Fable.Giraffe.Json compiles to json.erl which shadows OTP's json module.)
-[<Emit("giraffe_json_encoder:encode($0)")>]
+[<Emit("jsx:encode($0)")>]
 let private jsonEncode (term: obj) : string = nativeOnly
 
-[<Emit("giraffe_json_encoder:decode($0)")>]
+[<Emit("jsx:decode($0, [return_maps])")>]
 let jsonDecode (binary: byte array) : obj = nativeOnly
 
-[<Emit("erlang:is_map($0)")>]
-let private isMap (o: obj) : bool = nativeOnly
-
-[<Emit("erlang:is_atom($0)")>]
-let private isAtom (o: obj) : bool = nativeOnly
-
 /// Serialize an F# value to a JSON string (binary on BEAM).
-/// Relies on Fable-BEAM's record→map compilation (Phase 3).
-/// giraffe_json_encoder:encode/1 returns a binary directly.
 let serialize (value: obj) : string =
     jsonEncode value
 

--- a/src/beam/Middleware.fs
+++ b/src/beam/Middleware.fs
@@ -18,10 +18,6 @@ module GiraffeHandler =
     [<Emit("$0")>]
     let private taskToAsync (t: Task<'a>) : Async<'a> = nativeOnly
 
-    /// Erlang maps:from_list — converts list of tuples to map
-    [<Emit("maps:from_list($0)")>]
-    let private mapsFromList (pairs: obj) : obj = nativeOnly
-
     /// The Cowboy handler init callback.
     /// Called for every incoming request.
     let init (req: Req) (state: obj) : obj =
@@ -44,7 +40,7 @@ module GiraffeHandler =
         // (Empty body [||] compiles to [] on BEAM which is valid iodata.)
         let status = ctx.Response.StatusCode
         let body: string = byteArrayToBinary ctx.Response.Body |> unbox
-        let headerMap = mapsFromList (ctx.Response.GetHeadersMap())
+        let headerMap = Fable.Beam.Maps.maps.from_list (ctx.Response.GetHeadersMap())
         let req2 = CowboyReq.reply status headerMap body req
 
         CowboyHandler.ok req2 state

--- a/src/beam/WebHost.fs
+++ b/src/beam/WebHost.fs
@@ -37,10 +37,6 @@ module CowboyFFI =
     [<Emit("[$0]")>]
     let singletonList (x: obj) : obj = nativeOnly
 
-    /// Erlang io:format with a single argument (native list)
-    [<Emit("io:format($0, [$1])")>]
-    let ioFormat1 (fmt: string) (arg: obj) : unit = nativeOnly
-
 type IApplicationBuilder =
     abstract ApplicationServices: ServiceCollection with get, set
     abstract UseGiraffe: HttpHandler -> unit
@@ -81,7 +77,7 @@ type WebHostBuilder() =
                 let protoOpts = CowboyFFI.makeProtocolOpts dispatch
 
                 Cowboy.startClear CowboyFFI.httpAtom transportOpts protoOpts |> ignore
-                CowboyFFI.ioFormat1 "Starting Giraffe on port ~p~n" port
+                Fable.Beam.Io.format "Starting Giraffe on port ~p~n" [ box port ]
 
     member this.Configure(configureApp: Action<IApplicationBuilder>) =
         (this :> IWebHostBuilder).Configure(configureApp) |> ignore

--- a/uv.lock
+++ b/uv.lock
@@ -135,7 +135,7 @@ dev = [
 requires-dist = [
     { name = "fable-library", specifier = "==5.0.0rc3" },
     { name = "pydantic", specifier = ">=2.0.0" },
-    { name = "starlette", specifier = ">=0.38.5,<0.39" },
+    { name = "starlette", specifier = ">=1.0.0,<2" },
     { name = "structlog", specifier = ">=24.4.0,<25" },
 ]
 
@@ -395,14 +395,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.38.5"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/13/aa/57975da16ca0c368bbb5687daa6ad79561c2328a44667a1d6802e94df3e5/starlette-0.38.5.tar.gz", hash = "sha256:04a92830a9b6eb1442c766199d62260c3d4dc9c4f9188360626b1e0273cb7077", size = 2569511 }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/1a/8853ba4cea1ec99535ac9be5795a50ca92cddd04d57bbaa56e866cb7548c/starlette-0.38.5-py3-none-any.whl", hash = "sha256:632f420a9d13e3ee2a6f18f437b0a9f1faecb0bc42e1942aa2ea0e379a4c4206", size = 71447 },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Upgrade Fable CLI to 5.0.0-rc.5, Fable.Core to 5.0.0-rc.1, Fable.Python to 5.0.0-rc.2
- Add Fable.Beam and Fable.Beam.Cowboy dependencies, replacing hand-written `[<Emit>]` bindings for CowboyReq, CowboyRouter, Cowboy, CowboyHandler, Maps, and Io
- Switch BEAM JSON serialization to jsx (pure Erlang library) via rebar3 dependency
- Modernize BEAM build to use Fable's native rebar3 output format — no more manual `.erl` file copying
- Move all BEAM build output under `build/` (`build/apps/`, `build/_build/`) for consistency with Python output
- Update `FABLE_V5_BUGS.md`: mark fixed bugs in rc.5, document remaining ternary `await` issue

## Test plan
- [x] `just test` — all 50 Python tests pass
- [x] `just build-beam` — BEAM library compiles cleanly
- [x] `just app-beam` — example app starts, `/ping` returns `pong`, `/json` returns `{"age":53,"name":"Dag"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)