### PR TITLE
refactor: Upgrade to Fable 5.0.0-rc.6, remove ternary await workaround

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "5.0.0-rc.5",
+      "version": "5.0.0-rc.6",
       "commands": [
         "fable"
       ],

--- a/FABLE_V5_BUGS.md
+++ b/FABLE_V5_BUGS.md
@@ -1,6 +1,12 @@
 # Fable v5 Python Backend Bugs
 
-Bugs discovered while porting Fable.Giraffe to Fable v5. Updated for Fable 5.0.0-rc.5.
+Bugs discovered while porting Fable.Giraffe to Fable v5. Updated for Fable 5.0.0-rc.6.
+
+## Fixed in 5.0.0-rc.6
+
+### Missing `await` in ternary expressions
+
+Previously, when Fable compiled a two-branch `match` on a boolean into a Python ternary, it generated `await X if cond else Y` where `await` only applied to the true branch. In rc.6, Fable now generates `await (X if cond else Y)` with parentheses so both branches are correctly awaited.
 
 ## Fixed in 5.0.0-rc.5
 
@@ -12,49 +18,4 @@ Previously, when an F# function returned `Task<T>` by passing through if/match b
 
 Previously, using `match value with | :? SomeType as x -> ...` inside a closure would reassign the outer variable in the compiled Python, triggering `UnboundLocalError`. This appears to be fixed (no longer reproducible).
 
-## Still broken in 5.0.0-rc.5
-
-### Missing `await` in ternary expressions
-
-**Severity:** Critical
-**Affects:** Python backend
-
-When Fable compiles a simple two-branch `match` on a boolean into a Python ternary expression, only one branch gets `await`. This happens when the function returns `Task<T>` directly (pass-through) without a `task {}` CE.
-
-**F# input:**
-
-```fsharp
-let compose (handler1: HttpHandler) (handler2: HttpHandler) : HttpHandler =
-    fun (final: HttpFunc) ->
-        let func = final |> handler2 |> handler1
-        fun (ctx: HttpContext) ->
-            match ctx.Response.HasStarted with
-            | true -> final ctx
-            | false -> func ctx
-```
-
-**Generated Python (incorrect):**
-
-```python
-async def _arrow(ctx):
-    return await final(ctx) if has_started(ctx) else func(ctx)  # BUG: missing await on else branch
-```
-
-**Expected Python:**
-
-```python
-async def _arrow(ctx):
-    return await final(ctx) if has_started(ctx) else await func(ctx)
-```
-
-**Pattern:** Two-branch `match` on a boolean that Fable optimizes into a ternary expression. Multi-statement if/match blocks (which Fable emits as full `if/else` statements) are now correctly awaited.
-
-**Workaround:** Wrap in explicit `task { return! ... }` to force the task builder path, which avoids the raw ternary:
-
-```fsharp
-fun (ctx: HttpContext) -> task {
-    match ctx.Response.HasStarted with
-    | true -> return! final ctx
-    | false -> return! func ctx
-}
-```
+## No known bugs remaining in 5.0.0-rc.6

--- a/src/Core.fs
+++ b/src/Core.fs
@@ -22,11 +22,10 @@ module Core =
         fun (final: HttpFunc) ->
             let func = final |> handler2 |> handler1
 
-            fun (ctx: HttpContext) -> task {
+            fun (ctx: HttpContext) ->
                 match ctx.Response.HasStarted with
-                | true -> return! final ctx
-                | false -> return! func ctx
-            }
+                | true -> final ctx
+                | false -> func ctx
 
     let (>=>) = compose
 


### PR DESCRIPTION
## Summary
- Upgrades Fable from 5.0.0-rc.5 to 5.0.0-rc.6
- Removes the `task { return! ... }` workaround in `compose` — rc.6 fixes the ternary `await` bug by generating `await (X if cond else Y)` with parentheses
- Updates FABLE_V5_BUGS.md: no known bugs remaining

## Test plan
- [x] All 50 tests pass (native F# + compiled Python)
- [x] Verified generated Python uses correct `await` precedence in ternary expressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)