### PR TITLE
fix: point dev-mode BEAM compiler at the real Fable checkout

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,7 @@ dev := "false"
 fable := if dev == "true" { "dotnet run --project ../Fable/src/Fable.Cli --" } else { "dotnet fable" }
 
 # BEAM compiler: use local Fable checkout when dev=true, otherwise use dotnet fable
-fable_beam := if dev == "true" { "dotnet run --project ../fable/main/src/Fable.Cli --" } else { "dotnet fable" }
+fable_beam := if dev == "true" { "dotnet run --project ../Fable/src/Fable.Cli --" } else { "dotnet fable" }
 
 default:
     @just --list


### PR DESCRIPTION
`just dev=true build-beam` and `just dev=true app-beam` have been broken:

```
$ just dev=true build-beam
dotnet run --project ../fable/main/src/Fable.Cli -- src/beam ...
The provided file path does not exist: ../fable/main/src/Fable.Cli.
error: Recipe `build-beam` failed on line 27 with exit code 1
```

The `fable_beam` variable pointed at `../fable/main/src/Fable.Cli` — lowercase `fable`, plus a `main/` path segment that isn't there. On a case-sensitive filesystem it resolves to nothing.

```diff
-fable_beam := if dev == "true" { "dotnet run --project ../fable/main/src/Fable.Cli --" } else { "dotnet fable" }
+fable_beam := if dev == "true" { "dotnet run --project ../Fable/src/Fable.Cli --" } else { "dotnet fable" }
```

Now matches the `fable` variable declared directly above it.

## Why it went unnoticed

`test-beam` uses `{{fable}}`, not `{{fable_beam}}` — so the whole `just dev=true test` path works fine. Only `build-beam` and `app-beam` touch the broken variable, and neither runs in CI (CI runs `just test`). Nothing here affects the non-dev path.

## Verification

```
just dev=true build-beam
  Fable compilation finished in 2227ms
  ===> Compiling fable_giraffe_beam
  exit 0
```

Against a local Fable checkout at `../Fable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)