### PR TITLE
fix(beam): repair the Cowboy host, broken since Fable 5.8 module naming

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,7 @@ app: clean
 app-beam: build-beam
     {{fable_beam}} app/beam --exclude Fable.Core --lang beam --outDir {{build_path}}/apps/giraffe_app
     cd {{build_path}} && rebar3 compile
-    erl -pa {{build_path}}/_build/default/lib/*/ebin -noshell -eval "application:ensure_all_started(cowboy)" -eval "program:start()" -eval "receive stop -> ok end"
+    erl -pa {{build_path}}/_build/default/lib/*/ebin -noshell -eval "application:ensure_all_started(cowboy)" -eval "program_program:start()" -eval "receive stop -> ok end"
 
 # Compile the F# library to JavaScript (output: build/js/)
 build-js: clean

--- a/src/beam/WebHost.fs
+++ b/src/beam/WebHost.fs
@@ -16,9 +16,12 @@ module CowboyFFI =
     [<Emit("http")>]
     let httpAtom: Atom = nativeOnly
 
-    /// The Erlang module atom implementing the cowboy_handler behaviour
-    /// (Middleware.fs compiles to the `middleware` module).
-    [<Emit("middleware")>]
+    /// The Erlang module atom implementing the cowboy_handler behaviour.
+    /// Fable >= 5.8 qualifies generated BEAM module names with the source path inside the
+    /// assembly, so src/beam/Middleware.fs compiles to `src_beam_middleware` rather than
+    /// `middleware`. This atom is hand-written, so it has to track that name: move or rename
+    /// Middleware.fs and this must change with it, or Cowboy fails with `undef` on init/2.
+    [<Emit("src_beam_middleware")>]
     let middlewareAtom: Atom = nativeOnly
 
 type IApplicationBuilder =


### PR DESCRIPTION
`just app-beam` has been broken since Fable ≥5.8 started qualifying generated BEAM module names with the source path inside the assembly. Two hand-written references to the old bare names were never updated.

Found while verifying the commands in the README actually run.

## Two stale names

**1. `src/beam/WebHost.fs` — the library bug.** The `cowboy_handler` atom pointed at `middleware`, but `src/beam/Middleware.fs` now compiles to `src_beam_middleware`. Cowboy started and accepted the listener, then died on every request:

```
Ranch listener http, connection process <0.176.0>, stream 1 had its request process
exit with reason undef and stacktrace [{middleware,init,[...]}, ...
```

This affects **any consumer using `WebHostBuilder` on the BEAM**, not just the example app.

**2. `Justfile` — the `app-beam` recipe.** Invoked `program:start()`, but `app/beam/Program.fs` compiles to `program_program`, so the VM exited before Cowboy ever started:

```
{"init terminating in do_boot",{undef,[{program,start,[],[]}, ...
```

## Why the test suite missed it

The behavioral suite never exercises this path — `TestContext.create` builds an `HttpContext` directly and bypasses `WebHost` and the Cowboy handler entirely. BEAM tests were green throughout.

## Verification

```console
$ just app-beam
$ curl localhost:8080/ping
pong
$ curl localhost:8080/json
{"age":53,"name":"Dag"}
```

`just test` remains green on all three targets: Python 50, JavaScript 43 + 2 skipped, BEAM 37 + 8 skipped.

## Note on fragility

`middlewareAtom` is a hand-written `[<Emit>]`, so it is coupled to the *file path* of `Middleware.fs`. I expanded the comment to say so — move or rename that file and this atom must change with it. A Fable-level escape hatch for pinning generated module names would remove the coupling, but none exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)