### PR TITLE
docs: cover all three targets in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,17 @@
 Fable.Giraffe is a port of the
 [Giraffe](https://github.com/giraffe-fsharp/Giraffe) F# web framework to
 [Fable](https://github.com/fable-compiler/Fable/). Write your web application
-once in F# and run it on Python (ASGI/uvicorn) or Erlang/BEAM (Cowboy).
+once in F# and run it on three runtimes:
+
+| Target | Runtime | Server |
+|---|---|---|
+| Python | ASGI | uvicorn (Starlette) |
+| JavaScript | Node.js | built-in `node:http`, or mounted as `connect`/`express` middleware |
+| Erlang/BEAM | OTP | Cowboy |
 
 ## Example
+
+The handler pipeline is identical on every target:
 
 ```fsharp
 let webApp =
@@ -16,28 +24,46 @@ let webApp =
         route "/ping" >=> text "pong"
         route "/json" >=> json {| name = "Dag"; age = 53 |}
     ]
+```
 
+Only how you start the host differs:
+
+```fsharp
+// Python — returns an ASGI app for uvicorn
 let app =
     WebHostBuilder()
         .Configure(fun app -> app.UseGiraffe(webApp))
         .Build()
+
+// JavaScript — starts a node:http server
+WebHostBuilder()
+    .Configure(fun app -> app.UseGiraffe(webApp))
+    .Run(8080)
+
+// Erlang/BEAM — starts Cowboy
+let start () =
+    WebHostBuilder()
+        .Configure(fun app -> app.UseGiraffe(webApp))
+        .Build(8080)
 ```
 
 ## Prerequisites
 
 - .NET SDK 8+
 - Python >= 3.12 with [uv](https://github.com/astral-sh/uv)
-- Erlang/OTP 28+ (for BEAM target)
+- Node.js 20+ (JavaScript target)
+- Erlang/OTP 27+ with rebar3 (BEAM target)
 
 ## Build
 
 ```console
-just setup     # restore dotnet tools + uv sync
-just build     # compile F# library to Python (output: build/lib/)
-just build-beam  # compile F# library to Erlang (output: build/beam/)
+just setup       # restore dotnet tools + uv sync
+just build       # F# -> Python   (output: build/lib/)
+just build-js    # F# -> JavaScript (output: build/js/)
+just build-beam  # F# -> Erlang   (output: build/apps/giraffe/)
 ```
 
-For local Fable development (using a local Fable compiler checkout):
+For local Fable development (using a local Fable compiler checkout in `../Fable`):
 
 ```console
 just dev=true build
@@ -45,29 +71,34 @@ just dev=true build
 
 ## Running
 
-### Python (ASGI)
+Each of these compiles the example app in `app/` and serves it on port 8080.
 
 ```console
-just app
+just app       # Python — uvicorn
+just app-js    # JavaScript — node:http
+just app-beam  # Erlang/BEAM — Cowboy
 ```
-
-This compiles the example app and starts it with uvicorn on port 8080.
-
-### Erlang/BEAM (Cowboy)
-
-```console
-just app-beam
-```
-
-This compiles the example app to Erlang, builds with rebar3, and starts a Cowboy server on port 8080.
 
 ## Testing
 
+One shared behavioral suite in `test/shared/` runs on all three targets:
+
 ```console
-just test          # native F# tests + compiled Python tests
-just test-native   # native F# tests only (xUnit)
-just test-python   # compiled Python tests only (pytest)
+just test          # all three targets
+just test-python   # Python target
+just test-js       # JavaScript target
+just test-beam     # Erlang/BEAM target
+just test-native   # type-check the test projects on .NET (compile smoke only)
 ```
+
+Tests are written with [Scriptorium](https://github.com/fable-hub/Scriptorium) —
+Quill for the test DSL and runner, Nib for assertions — both of which compile to
+every target. Per-target divergences are marked with `skipIfBeam` /
+`skipIfJavaScript` next to the test, each carrying a comment explaining the gap,
+so they show up as skips rather than silently disappearing.
+
+There is no pure-.NET behavioral run: `src` is Fable-only bindings, so
+`test-native` is a compile smoke test.
 
 ## Benchmarks
 
@@ -81,3 +112,4 @@ connections (oha):
 | P99 latency | 2.49 ms | 3.50 ms | 34.2 ms |
 
 BEAM: Erlang/OTP 28, Cowboy. .NET: Giraffe on ASP.NET Core. Python: uvicorn, 1 worker.
+The JavaScript/Node target has not been benchmarked yet.


### PR DESCRIPTION
The README predated both the JavaScript/Node target and the Scriptorium test migration, so a fair amount of it was stale or wrong.

## What was wrong

| claim | reality |
|---|---|
| "run it on Python or Erlang/BEAM" | three targets — JavaScript/Node has been there since #13 |
| `just build-beam` → `build/beam/` | actually `build/apps/giraffe/` |
| no `build-js` / `app-js` documented | both exist |
| `just test` = "native F# tests + compiled Python tests" | runs the shared suite on all three targets |
| `just test-native` = "native F# tests only (xUnit)" | no xUnit anywhere; it's a .NET compile smoke test |
| `just test-python` = "pytest" | no pytest; the suite is Scriptorium (Quill + Nib) |
| Erlang/OTP 28+ | CI tests OTP 27 |
| no Node.js prerequisite | required for the JS target (CI uses 20) |

## What's new

- Targets presented as a table (runtime + server per target).
- The example now shows the handler pipeline once — it really is identical everywhere — then the three host entry points, which genuinely differ: `.Build()` returns an ASGI app for uvicorn, `.Run(8080)` starts `node:http`, `.Build(8080)` starts Cowboy.
- Testing section describes the actual setup: one shared suite in `test/shared/`, Scriptorium for DSL/runner/assertions, `skipIfBeam` / `skipIfJavaScript` for documented per-target gaps, and why there is no pure-.NET behavioral run.
- Benchmark table left as-is, with a note that the Node target hasn't been measured — I didn't want to invent a number.

## Verification

Every command in the README was actually run, not just read off the `Justfile`:

`just setup`, `just build` → `build/lib/`, `just build-js` → `build/js/`, `just build-beam` → `build/apps/giraffe/`, `just test` (50 / 43+2 / 37+8), `just test-native` (2 projects built), and all three app recipes curled on :8080 — `app` → `pong`, `app-js` → `pong`, `app-beam` → `pong` and `{"age":53,"name":"Dag"}`.

## Depends on #40

Verifying `just app-beam` is how I found it was broken — that's fixed in #40. This README documents it as working, which is true once #40 lands. Worth merging #40 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)