### PR TITLE
ci: automate release PRs with ShipIt and publish all three targets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,9 +6,38 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
+  shipit-pr:
+    name: ShipIt - Pull Request
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: "!startsWith(github.event.head_commit.message, 'chore: release ')"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 8.x
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: Install tools
+        run: dotnet tool restore
+
+      - name: ShipIt (Pull Request)
+        run: just shipit
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   publish:
+    name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: "startsWith(github.event.head_commit.message, 'chore: release ')"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+---
+last_commit_released: 3701c86dda14a263dc4d5cf4893f99159034dcde
+name: Fable.Giraffe
+---
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 0.12.0 - 2023-11-28
+
+Baseline release. Entries above this line are generated automatically by
+[EasyBuild.ShipIt](https://github.com/easybuild-org/EasyBuild.ShipIt) from
+[Conventional Commit](https://www.conventionalcommits.org/) messages.

--- a/Justfile
+++ b/Justfile
@@ -78,7 +78,9 @@ test-beam:
     cd {{build_path}}/tests-beam && erl -noshell -pa _build/default/lib/*/ebin -eval 'main:main([])'
 
 pack: build
-    dotnet pack -c Release {{src_path}}
+    dotnet pack -c Release src/python
+    dotnet pack -c Release src/js
+    dotnet pack -c Release src/beam
 
 format:
     dotnet fantomas src
@@ -88,10 +90,12 @@ setup:
     dotnet tool restore
     uv sync
 
-# Create NuGet packages with specific version (used in CI)
+# Create NuGet packages with specific version (used in CI) — Python, JS and BEAM
 pack-version version:
-    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} {{src_path}}
+    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/python
+    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/js
+    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/beam
 
-# Run EasyBuild.ShipIt for release management
+# Run EasyBuild.ShipIt for release management (opens/updates the release PR)
 shipit *args:
-    dotnet shipit --pre-release rc {{args}}
+    dotnet shipit {{args}}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,21 +21,28 @@ Other valid prefixes: `test`, `perf`, `ci`, `build`, `style`, `revert`.
 
 ## Creating a release
 
+Releases are automated. Every push to `main` runs the `shipit-pr` job in the
+publish workflow, which:
+
+1. Analyzes commits since the last release (tracked via `last_commit_released`
+   in `CHANGELOG.md`)
+2. Determines the next semantic version
+3. Opens (or updates) a **release pull request** titled `chore: release X.Y.Z`
+   with the updated `CHANGELOG.md`
+
+Review and merge that PR to ship. Merging lands a `chore: release X.Y.Z` commit
+on `main`, which triggers the `publish` job:
+
+1. Packs the NuGet packages (`Fable.Giraffe.Python`, `Fable.Giraffe.Js`,
+   `Fable.Giraffe.Beam`) at the release version
+2. Pushes them to nuget.org using the `NUGET_API_KEY` secret
+3. Creates the `vX.Y.Z` GitHub release
+
+To preview or generate the release PR locally instead:
+
 ```bash
 just shipit
 ```
-
-This will:
-
-1. Analyze commits since the last release
-2. Determine the next semantic version
-3. Update `CHANGELOG.md`
-4. Create a GitHub release with the version tag (e.g. `v0.1.0`)
-
-The GitHub release triggers the publish workflow, which:
-
-1. Packs all NuGet packages (`Fable.Giraffe.Python`, etc.)
-2. Pushes them to nuget.org using the `NUGET_API_KEY` secret
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Automates releases with [EasyBuild.ShipIt](https://github.com/easybuild-org/EasyBuild.ShipIt) (as in `Fable.Beam`) and extends publishing from Python-only to all three targets.

Every push to `main` now runs a `shipit-pr` job that opens/updates a `chore: release X.Y.Z` pull request from conventional-commit history. Merging that PR lands a `chore: release …` commit, which triggers the existing publish job — now packing and pushing **Fable.Giraffe.Python**, **Fable.Giraffe.Js**, and **Fable.Giraffe.Beam**.

## Changes

- **`CHANGELOG.md`** (new) — ShipIt's source of truth, with frontmatter seeded at the `v0.12.0` baseline (`last_commit_released` = the v0.12.0 commit), so the first release PR only includes commits since then.
- **`.github/workflows/publish.yml`** — added the `shipit-pr` job (runs on push to `main`, skipped on `chore: release` commits) and `pull-requests: write` permission. The publish job is unchanged in logic.
- **`Justfile`** — `pack` and `pack-version` now build all three packages; dropped `--pre-release rc` from the `shipit` recipe since this repo ships stable semver (`v0.12.0`), not `rc`.
- **`RELEASING.md`** — documents the automated PR flow and lists all three packages.

## Notes

- All three packages pack cleanly locally (verified with a test version). The push glob `src/**/Release/*.nupkg` already matches every target.
- The JS/BEAM fsprojs already carried full package metadata; no fsproj changes were needed.
- ⚠️ Requires **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** for the `shipit-pr` job to open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)