### PR TITLE
feat: adopt Fable 5 and start the 5.0.0 release line

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,8 @@ jobs:
           MESSAGE="${{ github.event.head_commit.message }}"
           VERSION="${MESSAGE#chore: release }"
           VERSION="${VERSION%% *}"
+          # ShipIt titles the PR "chore: release <name>@<version>"; strip the name@ prefix.
+          VERSION="${VERSION##*@}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
-last_commit_released: 3701c86dda14a263dc4d5cf4893f99159034dcde
+last_commit_released: 8f3057f04837d2b44ef72f2a225fff0050e62f19
 name: Fable.Giraffe
+force_version: 5.0.0
 ---
 
 # Changelog

--- a/Justfile
+++ b/Justfile
@@ -98,4 +98,4 @@ pack-version version:
 
 # Run EasyBuild.ShipIt for release management (opens/updates the release PR)
 shipit *args:
-    dotnet shipit {{args}}
+    dotnet shipit --skip-invalid-commit {{args}}


### PR DESCRIPTION
## Summary

Realigns the NuGet version to **5.0.0** to reflect that Fable.Giraffe targets **Fable 5** across all three backends. Merging this PR triggers the ShipIt automation, which will open a `chore: release Fable.Giraffe@5.0.0` PR; merging *that* publishes `Fable.Giraffe.Python`, `Fable.Giraffe.Js`, and `Fable.Giraffe.Beam` at `5.0.0` and cuts the `v5.0.0` GitHub release.

## How the version is pinned

ShipIt derives versions from conventional commits, which would give `0.13.0` from the `0.12.0` baseline. To jump straight to `5.0.0` I use ShipIt's [`force_version`](https://github.com/easybuild-org/EasyBuild.ShipIt#force_version) frontmatter field. It is **not persisted** into the generated changelog, so after the release PR merges, future releases compute normally from `5.0.0`.

Verified with `dotnet shipit --dry-run`:

```
│ Project       │ Status │ New Version │
│ Fable.Giraffe │   🚀   │    5.0.0    │
Title │ chore: release Fable.Giraffe@5.0.0
```

## Changes

- **`CHANGELOG.md`** — add `force_version: 5.0.0`; move `last_commit_released` to the current `main` tip so the 5.0.0 changelog starts clean (the 2023→now history contains non-conventional commits ShipIt can't parse).
- **`Justfile`** — `just shipit` now passes `--skip-invalid-commit`, so stray non-conventional commits (e.g. old dependabot bumps) skip instead of failing the run.
- **`.github/workflows/publish.yml`** — the publish job strips ShipIt's `<name>@` prefix from the release-PR title when extracting the version (`Fable.Giraffe@5.0.0` → `5.0.0`).

## Notes

- The `force_version` line self-clears: the release PR ShipIt generates will contain a `CHANGELOG.md` without it.
- Still requires **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** for the `shipit-pr` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)