### PR TITLE
feat: add shared htmlFile handler across all three backends

### DIFF
--- a/app/Program.fs
+++ b/app/Program.fs
@@ -18,6 +18,8 @@ let loggingHandler (source: HttpHandler) =
 
 let webApp =
     choose [
+        route "/" |> HttpHandler.htmlFile "public/index.html"
+
         route "/ping" |> HttpHandler.text "pong"
 
         route "/json"

--- a/src/Core.fs
+++ b/src/Core.fs
@@ -240,6 +240,25 @@ module Core =
             ctx.WriteBytesAsync bytes
 
     /// <summary>
+    /// Reads an HTML file from disk and writes its contents to the body of the HTTP response.
+    /// It also sets the HTTP Content-Type header to text/html and sets the Content-Length header accordingly.
+    /// </summary>
+    /// <remarks>
+    /// The file is read per request (so edits are picked up) and, unlike the .NET Giraffe handler, the read is
+    /// synchronous on every backend for now. <c>filePath</c> is an absolute path or one relative to the process
+    /// working directory — there is no ContentRoot concept on the Fable backends yet.
+    /// </remarks>
+    /// <param name="filePath">The absolute or working-directory-relative path to the HTML file.</param>
+    /// <returns>A Giraffe <see cref="HttpHandler" /> function which can be composed into a bigger web application.</returns>
+    let htmlFile (filePath: string) : HttpHandler =
+        let contentType = "text/html; charset=utf-8"
+
+        fun (_: HttpFunc) (ctx: HttpContext) ->
+            ctx.SetContentType contentType
+            let bytes = Encoding.UTF8.GetBytes(readFileText filePath)
+            ctx.WriteBytesAsync bytes
+
+    /// <summary>
     /// Serializes an object to JSON and writes the output to the body of the HTTP response.
     /// It also sets the HTTP Content-Type header to application/json and sets the Content-Length header accordingly.
     /// </summary>

--- a/src/HttpHandler.fs
+++ b/src/HttpHandler.fs
@@ -35,6 +35,17 @@ module HttpHandler =
     /// </returns>
     let inline text (str: string) (source: HttpHandler) : HttpHandler = source >=> text str
 
+    /// <summary>
+    /// Reads an HTML file from disk and writes its contents to the body of the HTTP response, setting the
+    /// Content-Type header to text/html and the Content-Length header accordingly.
+    /// </summary>
+    /// <param name="filePath">The absolute or working-directory-relative path to the HTML file.</param>
+    /// <param name="source">The previous HTTP handler to compose.</param>
+    /// <returns>
+    /// A Giraffe <see cref="HttpHandler" /> function which can be composed into a bigger web application.
+    /// </returns>
+    let inline htmlFile (filePath: string) (source: HttpHandler) : HttpHandler = source >=> htmlFile filePath
+
     let inline json (value: 'T) (source: HttpHandler) : HttpHandler = source >=> json value
 
     let inline route (path: string) (source: HttpHandler) : HttpHandler = source >=> route path

--- a/src/beam/PlatformHelpers.fs
+++ b/src/beam/PlatformHelpers.fs
@@ -17,3 +17,10 @@ module PlatformHelpers =
 
     [<Emit("ok")>]
     let okAtom: obj = nativeOnly
+
+    /// Read a file's contents as a UTF-8 string. `file:read_file/1` returns
+    /// `{ok, Binary}` on success — an Erlang binary, which is already the
+    /// representation of an F# string on BEAM, so no decoding is needed.
+    /// `path` is absolute or relative to the node's working directory.
+    [<Emit("element(2, file:read_file($0))")>]
+    let readFileText (path: string) : string = nativeOnly

--- a/src/js/PlatformHelpers.fs
+++ b/src/js/PlatformHelpers.fs
@@ -1,5 +1,7 @@
 namespace Fable.Giraffe
 
+open Fable.Core
+
 [<AutoOpen>]
 module PlatformHelpers =
     /// Length of a sequence/byte array. On JS this is a plain number; no
@@ -8,3 +10,12 @@ module PlatformHelpers =
 
     /// On JS there is no separate boxed-int type, so this is the identity.
     let inline toNativeInt (x: int) : int = x
+
+    /// `fs.readFileSync`. The encoding arg is required — without it Node returns
+    /// a Buffer rather than a string.
+    [<Import("readFileSync", "node:fs")>]
+    let private readFileSync (path: string) (encoding: string) : string = nativeOnly
+
+    /// Read a file's contents as a UTF-8 string. Synchronous (blocks the event
+    /// loop); `path` is absolute or relative to the process working directory.
+    let readFileText (path: string) : string = readFileSync path "utf8"

--- a/src/python/PlatformHelpers.fs
+++ b/src/python/PlatformHelpers.fs
@@ -1,5 +1,7 @@
 namespace Fable.Giraffe
 
+open Fable.Core
+
 [<AutoOpen>]
 module PlatformHelpers =
     [<Fable.Core.Emit("len($0)")>]
@@ -9,3 +11,9 @@ module PlatformHelpers =
     /// ASGI (h11/uvicorn) requires native int for status codes etc.
     [<Fable.Core.Emit("int($0)")>]
     let toNativeInt (x: int) : int = x
+
+    /// Read a file's contents as a UTF-8 string. Synchronous (blocks the event
+    /// loop); `path` is absolute or relative to the process working directory.
+    /// CPython closes the handle via refcounting once `read()` returns.
+    [<Emit("open($0, encoding='utf-8').read()")>]
+    let readFileText (path: string) : string = nativeOnly


### PR DESCRIPTION
## What

Ports Giraffe's `htmlFile` file-serving handler to shared `src/` so it runs identically on the **Python, JS, and BEAM** targets, composable with `>=>` like `text`/`json`.

## Why

`htmlFile` is a genuine *Giraffe-layer* handler (unlike `UseStaticFiles`, which is ASP.NET Core middleware and stays a per-host feature). Putting it in shared code aligns the backends: one implementation, three targets.

## How

- **`src/Core.fs`** — `htmlFile: string -> HttpHandler`. Reads the file per request as a UTF-8 string and writes it through the existing `Encoding.UTF8.GetBytes → WriteBytesAsync` path, so **Content-Length and HEAD handling are inherited unchanged** from `text`.
- **`src/HttpHandler.fs`** — the pipeline-composable `HttpHandler.htmlFile` wrapper, matching the `text`/`json` pattern.
- **`src/{python,js,beam}/PlatformHelpers.fs`** — a new per-target `readFileText` primitive:
  | Target | Emit |
  |---|---|
  | Python | `open($0, encoding='utf-8').read()` |
  | JS | `readFileSync` from `node:fs`, called with `"utf8"` |
  | BEAM | `element(2, file:read_file($0))` — the `{ok, Binary}` binary is already an F# string on BEAM |

Reading as a **string** (not bytes) reuses the proven encoding path and sidesteps BEAM's raw-binary/`byte_array` mismatch.

- **`app/Program.fs`** — serves `public/index.html` at `/` via `htmlFile` as a live demo.

## Known limitations (documented on the handler)

- Synchronous read (blocks the event loop on Python/JS; fine on BEAM). Can go async per-target later behind the same signature.
- No `ContentRoot` concept — paths are absolute or process-working-directory-relative.
- No `streamFile`/range support — deliberately deferred; better served by native static handlers.

## Verification

- Native type-check: clean, 0 warnings
- All three Fable targets compile and pass the existing suite (Python 50, JS 43+2 skip, BEAM 37+8 skip)
- Inspected generated Python/JS/Erlang — the emit inlines correctly and routes through `WriteBytesAsync` on each
- Fantomas: clean
- End-to-end on Python (live uvicorn): `GET /` → `200`, `text/html; charset=utf-8`, `content-length: 532`; `HEAD /` → correct headers, empty body; existing routes unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)