### PR TITLE
feat: add UseStaticFiles for the BEAM and JS backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ Fable.Giraffe.sln.DotSettings.user
 .fake
 .claude/worktrees/
 erl_crash.dump
+
+# npm — runtime deps for the JS/Node backend (package-lock.json is committed)
+node_modules/

--- a/Justfile
+++ b/Justfile
@@ -45,6 +45,7 @@ build-js: clean
 
 # Build + start the example app on Node's built-in http server (port 8080)
 app-js: clean
+    npm install
     mkdir -p {{build_path}}
     {{fable}} app/js --exclude Fable.Core --lang javascript --outDir {{build_path}}/app-js
     echo '{"type":"module"}' > {{build_path}}/app-js/package.json
@@ -89,6 +90,7 @@ format:
 setup:
     dotnet tool restore
     uv sync
+    npm install
 
 # Create NuGet packages with specific version (used in CI) — Python, JS and BEAM
 pack-version version:

--- a/app/beam/Program.fs
+++ b/app/beam/Program.fs
@@ -16,5 +16,6 @@ let webApp =
 let start () =
     WebHostBuilder()
         .Configure(fun app ->
+            app.UseStaticFiles("/static", "app/public")
             app.UseGiraffe(webApp))
         .Build(8080)

--- a/app/js/Program.fs
+++ b/app/js/Program.fs
@@ -38,5 +38,7 @@ let webApp =
 WebHostBuilder()
     .ConfigureLogging(fun builder -> builder.SetMinimumLevel(LogLevel.Debug))
     .UseConsoleLogging()
-    .Configure(fun app -> app.UseGiraffe(webApp))
+    .Configure(fun app ->
+        app.UseStaticFiles("/static", "app/public")
+        app.UseGiraffe(webApp))
     .Run(8080)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,238 @@
+{
+  "name": "fable-giraffe",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fable-giraffe",
+      "dependencies": {
+        "serve-static": "^2.2.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fable-giraffe",
+  "private": true,
+  "description": "Runtime npm dependencies for the Fable.Giraffe JS/Node backend (the compiled library imports these).",
+  "dependencies": {
+    "serve-static": "^2.2.0"
+  }
+}

--- a/src/beam/WebHost.fs
+++ b/src/beam/WebHost.fs
@@ -22,9 +22,30 @@ module CowboyFFI =
     [<Emit("src_beam_middleware")>]
     let middlewareAtom: Atom = nativeOnly
 
+    /// Cowboy's built-in static-file handler module. We delegate the whole static-serving
+    /// problem — mime detection, ETags, Range requests, conditional requests — to it rather
+    /// than reimplement any of that.
+    [<Emit("cowboy_static")>]
+    let cowboyStaticAtom: Atom = nativeOnly
+
+    /// cowboy_static init state serving a directory: `{dir, Dir, [{mimetypes, cow_mimetypes, all}]}`.
+    /// `Dir` is a binary here (an F# string on BEAM); cowboy_static's `absname/1` accepts binaries.
+    /// The mimetypes extra routes content-type guessing through cowlib's cow_mimetypes:all/1.
+    [<Emit("{dir, $0, [{mimetypes, cow_mimetypes, all}]}")>]
+    let dirState (directory: string) : obj = nativeOnly
+
 type IApplicationBuilder =
     abstract ApplicationServices: ServiceCollection with get, set
     abstract UseGiraffe: HttpHandler -> unit
+
+    /// Serve files from <c>directory</c> under the URL prefix <c>requestPath</c> (e.g.
+    /// <c>UseStaticFiles("/static", "public")</c> maps <c>GET /static/app.css</c> to
+    /// <c>public/app.css</c>). Requests that don't match the prefix fall through to Giraffe.
+    ///
+    /// Unlike the Python/JS backends there is no root-mount (empty-prefix) form: Cowboy routing
+    /// is exclusive longest-prefix matching with no fall-through, so a root static mount would
+    /// shadow the Giraffe catch-all entirely. A prefix is therefore required.
+    abstract UseStaticFiles: string * string -> unit
 
 type IWebHostBuilder =
     abstract Configure: Action<IApplicationBuilder> -> IWebHostBuilder
@@ -34,6 +55,7 @@ type WebHostBuilder() =
     let loggerFactory = LoggerFactory.Create()
     let services = ServiceCollection()
     let mutable handler: HttpHandler option = None
+    let staticMounts = ResizeArray<string * string>()
 
     interface IWebHostBuilder with
         member this.Configure(configureApp: Action<IApplicationBuilder>) =
@@ -43,7 +65,10 @@ type WebHostBuilder() =
                         with get () = services
                         and set _ = ()
 
-                    member _.UseGiraffe(h: HttpHandler) = handler <- Some h }
+                    member _.UseGiraffe(h: HttpHandler) = handler <- Some h
+
+                    member _.UseStaticFiles(requestPath: string, directory: string) =
+                        staticMounts.Add(requestPath, directory) }
 
             configureApp.Invoke(app)
             this
@@ -52,13 +77,24 @@ type WebHostBuilder() =
             match handler with
             | None -> failwith "No handler configured. Call UseGiraffe in Configure."
             | Some h ->
-                // Build Cowboy routing dispatch: all paths → middleware module with the handler
-                // AND the services collection as state, so the request handler can resolve
-                // services (logger, etc.) off the context via GetService.
+                // Build Cowboy routing dispatch. Static mounts are compiled to cowboy_static
+                // routes at their URL prefix and placed AHEAD of the Giraffe catch-all, since
+                // Cowboy matches the most specific route and never falls through.
+                let staticRoutes =
+                    staticMounts
+                    |> Seq.map (fun (requestPath, directory) ->
+                        CowboyRouter.route (requestPath + "/[...]") CowboyFFI.cowboyStaticAtom (CowboyFFI.dirState directory))
+                    |> List.ofSeq
+
+                // Catch-all: every remaining path → middleware module with the handler AND the
+                // services collection as state, so the request handler can resolve services
+                // (logger, etc.) off the context via GetService.
                 let catchAllRoute =
                     CowboyRouter.route "/[...]" CowboyFFI.middlewareAtom (h, services)
 
-                let hostRule = CowboyRouter.hostRule CowboyRouter.wildcard [ catchAllRoute ]
+                let hostRule =
+                    CowboyRouter.hostRule CowboyRouter.wildcard (staticRoutes @ [ catchAllRoute ])
+
                 let dispatch = CowboyRouter.compile [ hostRule ]
 
                 let transportOpts = Cowboy.tcpPort port

--- a/src/js/Server.fs
+++ b/src/js/Server.fs
@@ -27,6 +27,56 @@ module Server =
     [<Import("createServer", "node:http")>]
     let private createServer (handler: Func<IncomingMessage, ServerResponse, unit>) : HttpServer = nativeOnly
 
+    /// A Connect-style middleware `(req, res, next) -> unit`.
+    type private Middleware = Func<IncomingMessage, ServerResponse, (unit -> unit), unit>
+
+    /// `serve-static` — the library behind `express.static`. We delegate the whole static-file
+    /// problem to it (content-type detection, ETags, Range requests, conditional requests,
+    /// Cache-Control); on a miss it invokes `next`, so the request falls through to Giraffe.
+    [<Import("default", "serve-static")>]
+    let private serveStatic (root: string) : Middleware = nativeOnly
+
+    /// Node's `IncomingMessage.url` is mutable and serve-static matches against it. To mount a
+    /// directory under a URL prefix we strip the prefix before delegating (serve-static, unlike
+    /// `express`, does not know about mount paths) and restore it if the file isn't found.
+    [<Emit("$0.url = $1")>]
+    let private setUrl (req: IncomingMessage) (url: string) : unit = nativeOnly
+
+    /// Compose the configured static mounts into a single pre-Giraffe middleware. Each
+    /// `(requestPath, directory)` is tried in order; the first that serves a file ends the
+    /// request, otherwise `next` runs (the next mount, and finally Giraffe). An empty
+    /// `requestPath` mounts at the root — the request path is passed to serve-static as-is.
+    let private staticPipeline (mounts: (string * string) list) : Middleware =
+        let stages =
+            mounts
+            |> List.map (fun (prefix, dir) -> prefix, serveStatic dir)
+
+        Func<_, _, _, _>(fun (req: IncomingMessage) (res: ServerResponse) (next: unit -> unit) ->
+            let rec go stages =
+                match stages with
+                | [] -> next ()
+                | (prefix: string, mw: Middleware) :: rest ->
+                    if prefix = "" then
+                        mw.Invoke(req, res, (fun () -> go rest))
+                    elif
+                        req.url = prefix
+                        || req.url.StartsWith(prefix + "/")
+                    then
+                        let original = req.url
+                        setUrl req (req.url.Substring(prefix.Length))
+
+                        mw.Invoke(
+                            req,
+                            res,
+                            (fun () ->
+                                setUrl req original
+                                go rest)
+                        )
+                    else
+                        go rest
+
+            go stages)
+
     /// Run the Giraffe handler for a single request. If the pipeline never wrote
     /// a response, `onUnhandled` decides what happens (call the host's `next`, or
     /// answer 404 in standalone mode).
@@ -64,12 +114,23 @@ module Server =
     /// Expose the Giraffe handler as a Connect/Express middleware
     /// `(req, res, next) -> unit`. Mount with `app.use(...)` after any other
     /// Node middleware; unmatched requests fall through via `next()`.
-    let toMiddleware (handler: HttpHandler) (services: ServiceCollection) : Func<IncomingMessage, ServerResponse, (unit -> unit), unit> =
-        Func<_, _, _, _>(fun req res next -> dispatch handler services req res next)
+    ///
+    /// Configured static mounts run first (serve-static), then Giraffe, then the host's `next`.
+    let toMiddleware
+        (mounts: (string * string) list)
+        (handler: HttpHandler)
+        (services: ServiceCollection)
+        : Func<IncomingMessage, ServerResponse, (unit -> unit), unit> =
+        let statics = staticPipeline mounts
 
-    /// Start a zero-dependency `http` server driving the Giraffe handler.
-    /// Unmatched requests get a 404 (there is no outer host to fall through to).
-    let run (handler: HttpHandler) (services: ServiceCollection) (port: int) : unit =
+        Func<_, _, _, _>(fun req res next -> statics.Invoke(req, res, (fun () -> dispatch handler services req res next)))
+
+    /// Start a zero-framework `http` server driving the Giraffe handler. Configured static
+    /// mounts (serve-static) are tried first; unmatched requests get a 404 (there is no outer
+    /// host to fall through to).
+    let run (mounts: (string * string) list) (handler: HttpHandler) (services: ServiceCollection) (port: int) : unit =
+        let statics = staticPipeline mounts
+
         let listener =
             Func<IncomingMessage, ServerResponse, unit>(fun req res ->
                 let send404 () =
@@ -77,6 +138,6 @@ module Server =
                     res.setHeader ("content-type", "text/plain; charset=utf-8")
                     res.``end`` (box "Not Found")
 
-                dispatch handler services req res send404)
+                statics.Invoke(req, res, (fun () -> dispatch handler services req res send404)))
 
         (createServer listener).listen (port, (fun () -> printfn "Giraffe listening on http://localhost:%d" port))

--- a/src/js/WebHost.fs
+++ b/src/js/WebHost.fs
@@ -10,6 +10,12 @@ type IApplicationBuilder =
     abstract ApplicationServices: ServiceCollection with get, set
     abstract UseGiraffe: HttpHandler -> unit
 
+    /// Serve files from <c>directory</c> under the URL prefix <c>requestPath</c> (e.g.
+    /// <c>UseStaticFiles("/static", "public")</c> maps <c>GET /static/app.css</c> to
+    /// <c>public/app.css</c>). An empty <c>requestPath</c> mounts at the root. Requests that
+    /// don't resolve to a file fall through to Giraffe. Backed by serve-static.
+    abstract UseStaticFiles: string * string -> unit
+
 /// Host builder for the JS/Node backend.
 ///
 /// Unlike the Python backend (which returns an ASGI app for uvicorn to serve),
@@ -20,11 +26,14 @@ type WebHostBuilder() =
     let loggerFactory = LoggerFactory.Create()
     let services = ServiceCollection()
     let mutable handler: HttpHandler option = None
+    let staticMounts = ResizeArray<string * string>()
 
     member private _.Handler =
         match handler with
         | Some h -> h
         | None -> failwith "No handler configured. Call UseGiraffe in Configure."
+
+    member private _.StaticMounts = List.ofSeq staticMounts
 
     member this.Configure(configureApp: Action<IApplicationBuilder>) =
         let app =
@@ -33,7 +42,10 @@ type WebHostBuilder() =
                     with get () = services
                     and set _ = ()
 
-                member _.UseGiraffe(h: HttpHandler) = handler <- Some h }
+                member _.UseGiraffe(h: HttpHandler) = handler <- Some h
+
+                member _.UseStaticFiles(requestPath: string, directory: string) =
+                    staticMounts.Add(requestPath, directory) }
 
         configureApp.Invoke(app)
         this
@@ -49,10 +61,19 @@ type WebHostBuilder() =
 
     /// Expose the app as a Connect/Express middleware for `app.use(...)`.
     member this.ToMiddleware() =
-        Server.toMiddleware this.Handler services
+        Server.toMiddleware this.StaticMounts this.Handler services
 
-    /// Start a zero-dependency Node `http` server on `port`.
-    member this.Run(port: int) = Server.run this.Handler services port
+    /// Start a Node `http` server on `port`.
+    member this.Run(port: int) =
+        Server.run this.StaticMounts this.Handler services port
 
 module Host =
     let CreateDefaultBuilder (_: string array) = WebHostBuilder()
+
+[<AutoOpen>]
+module Extensions =
+    type IApplicationBuilder with
+
+        /// Serve files from <c>directory</c> at the URL root, falling through to Giraffe on a
+        /// miss. Shorthand for <c>UseStaticFiles("", directory)</c>.
+        member x.UseStaticFiles(directory: string) = x.UseStaticFiles("", directory)


### PR DESCRIPTION
## What

Brings static-file serving to the **BEAM** and **JS** hosts behind the same ASP.NET-shaped `UseStaticFiles(requestPath, directory)` API the Python backend already exposes.

## Why — lean on platform deps

Each backend delegates to its platform's **native, production-grade** static server rather than reimplementing mime detection, ETags, ranges, conditional requests, and caching — the same way Giraffe leans on ASP.NET Core. This is the intended super-power of a multi-target Fable framework: use the best library on each platform instead of a lowest-common-denominator port.

| Backend | Native server | Semantics |
|---|---|---|
| Python | Starlette `StaticFiles` | already shipped |
| BEAM | `cowboy_static` | **new** |
| JS/Node | `serve-static` | **new** |

## How

- **BEAM** (`src/beam/WebHost.fs`) — `UseStaticFiles` compiles a `cowboy_static` route at the URL prefix, placed **ahead of the Giraffe catch-all** in the Cowboy dispatch. Cowboy routing is *exclusive* (no fall-through), so a URL prefix is **required** — a root mount would shadow Giraffe. That constraint is documented on the interface member. `cowboy_static` accepts a binary `dir` and mime detection is routed through cowlib's `cow_mimetypes:all/1`.

- **JS** (`src/js/Server.fs`, `WebHost.fs`) — adds a middleware chain to the host. `UseStaticFiles` registers a `serve-static` instance that runs **before** Giraffe and falls through via `next()` on a miss, matching ASP.NET's root-or-prefix semantics. For a prefix mount the URL prefix is stripped before delegating (serve-static, unlike express, doesn't know mount paths) and restored on miss. A 1-arg `UseStaticFiles(directory)` root-mount overload mirrors Python.

- **serve-static is the JS backend's first runtime npm dependency** — root `package.json` + `npm install` wired into `just app-js` and `just setup`; `node_modules/` gitignored, `package-lock.json` committed. The backend's zero-dep stance was about not depending on a web *framework* (Express) for the request loop, not on focused utilities. The import is only on the host path, so **`just test-js` still runs without it installed** (verified).

- Both example apps mount `app/public` at `/static`, demonstrating the identical 2-arg API across backends.

## Verification

- Native type-check: all three src projects build, 0 errors
- Full suite green on all three targets (Python 50, JS 43+2 skip, BEAM 37+8 skip)
- Fantomas clean on all changed `src/` files (`app/` is hand-maintained, not in `just format`)
- **End-to-end, live servers:**
  - **JS** — `GET /static/` → 200 with `ETag`, `Accept-Ranges`, `Cache-Control`, `Last-Modified`; `/static/favicon.png` → `Content-Type: image/png`; `/ping` falls through to Giraffe; missing file → 404
  - **BEAM** — `GET /static/index.html` → 200 with `etag`, `last-modified`, `accept-ranges`, `content-type: text/html`; `/static/favicon.png` → `image/png`; `/ping` and `/json` fall through to Giraffe

## Follow-up

Python `UseStaticFiles` is unchanged (still 1-arg root-fallthrough). Adding the 2-arg prefix form there for full symmetry is a sensible next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)