### PR TITLE
feat: add prefix-mount UseStaticFiles form to the Python backend

### DIFF
--- a/app/Program.fs
+++ b/app/Program.fs
@@ -34,6 +34,6 @@ let app =
         .ConfigureLogging(fun builder -> builder.SetMinimumLevel(LogLevel.Debug))
         .UseStructlog()
         .Configure(fun app ->
-            app.UseStaticFiles("public")
+            app.UseStaticFiles("/static", "public")
             app.UseGiraffe(webApp))
         .Build()

--- a/src/python/StaticFiles.fs
+++ b/src/python/StaticFiles.fs
@@ -22,17 +22,44 @@ module StaticFilesMiddleware =
 
     type IApplicationBuilder with
 
-        member x.UseStaticFiles(directory: string) : unit =
+        /// Serve files from <c>directory</c> under the URL prefix <c>requestPath</c> (e.g.
+        /// <c>UseStaticFiles("/static", "public")</c> maps <c>GET /static/app.css</c> to
+        /// <c>public/app.css</c>). An empty <c>requestPath</c> mounts at the root. Requests that
+        /// don't resolve to a file fall through to the rest of the pipeline (i.e. Giraffe). This
+        /// matches the BEAM/JS backends' 2-arg form; backed here by Starlette's StaticFiles.
+        member x.UseStaticFiles(requestPath: string, directory: string) : unit =
             x.UseMiddleware(fun app loggerFactory ->
                 let middleware = StaticFiles.Create(directory)
 
-                let inline asgi (scope: Scope) (receive: unit -> Task<Response>) (send: Request -> Task<unit>) =
+                let asgi (scope: Scope) (receive: unit -> Task<Response>) (send: Request -> Task<unit>) =
                     task {
-                        try
-                            do! middleware.InvokeAsync(scope, receive, send)
-                        with ex ->
+                        let path = scope["path"] :?> string
+
+                        let matches =
+                            requestPath = ""
+                            || path = requestPath
+                            || path.StartsWith(requestPath + "/")
+
+                        if matches then
+                            // Strip the mount prefix so Starlette's StaticFiles resolves the file
+                            // relative to `directory` (the same rewrite a Starlette Mount does).
+                            // On a miss StaticFiles raises, so restore the original path before the
+                            // fall-through to Giraffe.
+                            let stripped = path.Substring(requestPath.Length)
+                            scope["path"] <- (if stripped = "" then "/" else stripped)
+
+                            try
+                                do! middleware.InvokeAsync(scope, receive, send)
+                            with _ ->
+                                scope["path"] <- path
+                                do! app.Invoke(scope, receive, send)
+                        else
                             do! app.Invoke(scope, receive, send)
                     }
 
                 Func<Scope, unit -> Task<Response>, Request -> Task<unit>, Task<unit>>(asgi))
             |> ignore
+
+        /// Serve files from <c>directory</c> at the URL root, falling through to Giraffe on a
+        /// miss. Shorthand for <c>UseStaticFiles("", directory)</c>.
+        member x.UseStaticFiles(directory: string) : unit = x.UseStaticFiles("", directory)


### PR DESCRIPTION
## What

Completes the cross-backend symmetry started in #49. The **Python** backend now exposes the same 2-arg `UseStaticFiles(requestPath, directory)` prefix form as BEAM and JS, alongside its existing 1-arg root-mount form.

```fsharp
app.UseStaticFiles("/static", "public")   // NEW: prefix mount
app.UseStaticFiles("public")              // still works — now shorthand for ("", "public")
```

After this, all three backends share the same `UseStaticFiles(requestPath, directory)` API:

| Backend | Native server | Root form | Prefix form |
|---|---|---|---|
| Python | Starlette `StaticFiles` | ✅ | ✅ (this PR) |
| JS | serve-static | ✅ | ✅ (#49) |
| BEAM | cowboy_static | — (Cowboy can't fall through) | ✅ (#49) |

## How

Starlette's `StaticFiles` resolves files against the whole `scope["path"]`, so to mount under a URL prefix the middleware **rewrites `scope["path"]`** to strip the prefix before delegating — the same rewrite a Starlette `Mount` performs — and restores it on a miss so the fall-through to Giraffe sees the original path. Requests outside the prefix skip `StaticFiles` entirely and go straight to Giraffe. The 1-arg form now delegates to `UseStaticFiles("", directory)`, where the empty prefix preserves the original root-mount behavior exactly.

## Verification

- Native build: 0 errors; Fantomas clean
- Full suite green on all three targets (Python 50, JS 43+2 skip, BEAM 37+8 skip) — the change is Python-only
- **End-to-end (uvicorn)**, example app mounting `public` at `/static` to match the JS/BEAM apps:
  - `GET /static/index.html`, `GET /static/favicon.png` → served with mime (`image/png`) + ETag/Last-Modified
  - `GET /` → `htmlFile` (a non-static route), `GET /ping` → Giraffe
  - `GET /static/missing.css` → falls through to Giraffe 404
  - `GET /staticfoo` → does **not** match the `/static` prefix (boundary check), falls through

🤖 Generated with [Claude Code](https://claude.com/claude-code)