### PR TITLE
fix: restore a real project in the release job and add a manual trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,14 @@ name: Publish NuGet
 on:
   push:
     branches: [main]
+  # Manual escape hatch: lets a failed or missed release be re-run without having to
+  # hand-craft a `chore: release ...` commit on main.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 5.0.0)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,7 +21,7 @@ jobs:
     name: ShipIt - Pull Request
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: "!startsWith(github.event.head_commit.message, 'chore: release ')"
+    if: "github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: release ')"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -40,7 +48,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: "startsWith(github.event.head_commit.message, 'chore: release ')"
+    if: "github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: release ')"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -55,19 +63,26 @@ jobs:
 
       - name: Extract version
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          MESSAGE="${{ github.event.head_commit.message }}"
-          VERSION="${MESSAGE#chore: release }"
-          VERSION="${VERSION%% *}"
-          # ShipIt titles the PR "chore: release <name>@<version>"; strip the name@ prefix.
-          VERSION="${VERSION##*@}"
+          if [ -n "$INPUT_VERSION" ]; then
+            # Manual run: take the version straight from the dispatch input.
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${COMMIT_MESSAGE#chore: release }"
+            VERSION="${VERSION%% *}"
+            # ShipIt titles the PR "chore: release <name>@<version>"; strip the name@ prefix.
+            VERSION="${VERSION##*@}"
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Restore dependencies
         run: |
           dotnet tool restore
-          dotnet restore src
+          dotnet restore Fable.Giraffe.sln
 
       - name: Pack NuGet
         run: just pack-version ${{ steps.version.outputs.version }}


### PR DESCRIPTION
The 5.0.0 release failed at **Restore dependencies** ([run](https://github.com/dbrattli/Fable.Giraffe/actions/runs/30042727625/job/89326352526)):

```
MSBUILD : error MSB1003: Specify a project or solution file.
The current working directory does not contain a project or solution file.
```

## Why

`dotnet restore src` has never been able to work. `src/` contains no project or solution file — the three packable projects live in `src/python`, `src/js` and `src/beam`.

It went unnoticed because the two jobs in this workflow are **mutually exclusive** on the commit message:

| Job | Runs when |
|---|---|
| `shipit-pr` | commit message does **not** start with `chore: release ` |
| `publish` (Release) | commit message **does** start with `chore: release ` |

So the Release job had never actually executed until the 5.0.0 release commit. Every prior green "Publish NuGet" run was the ShipIt job. Nothing was published and no tag was cut, so 5.0.0 still needs to go out.

Not related to the remoting work in #51 — that PR's own run passed, and the failure reproduces on any commit reaching this job.

## Changes

**Restore the solution** rather than a directory with no project in it. `Fable.Giraffe.sln` already covers all three targets, so this stays correct if a fourth is added.

**Add a `workflow_dispatch` trigger with a version input.** Previously a release could *only* be triggered by pushing a commit whose message starts with `chore: release `, which makes recovering a failed release awkward — re-running the failed job does not help, because a push-triggered run uses the workflow file from the commit that triggered it, bug and all. The version step now prefers the dispatch input and falls back to parsing the commit message; both job guards account for the new event.

**Harden the version step.** The commit message moves out of direct `${{ }}` shell interpolation into an env var, so a crafted commit message cannot inject shell into the runner.

## Verification (local)

- `dotnet restore src` reproduces MSB1003; `dotnet restore Fable.Giraffe.sln` succeeds
- `just pack-version 5.0.0` produces all three nupkgs under `src/*/bin/Release/`
- the `src/**/Release/*.nupkg` push glob resolves — tested against a local folder feed, so the step after the failure is confirmed good too
- version extraction is correct for all four cases:

| Input | Result |
|---|---|
| push, `chore: release Fable.Giraffe@5.0.0 (#47)` | `5.0.0` / `v5.0.0` |
| push, `chore: release 5.1.0` | `5.1.0` / `v5.1.0` |
| dispatch input `5.0.0` | `5.0.0` / `v5.0.0` |
| dispatch input wins over commit message | `5.2.0` / `v5.2.0` |

## After merging

Release 5.0.0 from the Actions tab: **Publish NuGet → Run workflow → version `5.0.0`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)