### PR TITLE
feat: enable remoting on the BEAM target

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "fable": {
-      "version": "5.12.0",
+      "version": "5.13.0",
       "commands": [
         "fable"
       ],

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,14 +78,18 @@ type HttpHandler = HttpFunc -> HttpFunc
 
 ### Remoting
 
-`src/Remoting.fs` is shared. It reflects over a record of `... -> Async<'T>` fields and generates one
-sub-route per field under `/{ApiName}`. Only three small primitives are target-specific, and they sit
-behind `PlatformHelpers`:
+`src/Remoting.fs` is shared across **all three** targets (Python, JS, BEAM). It reflects over a record
+of `... -> Async<'T>` fields and generates one sub-route per field under `/{ApiName}`. Only three
+small primitives are target-specific, and they sit behind `PlatformHelpers`:
 
 - `startAsTask` — Async->Task bridge. Direct on Python; JS routes through `Async.StartAsPromise`
-  because fable-library-js has no `startAsTask` (`Async.StartAsTask` fails to link at runtime).
+  because fable-library-js has no `startAsTask` (`Async.StartAsTask` fails to link at runtime); on
+  BEAM it is the identity (`unbox`), since `task` is a CPS alias for `Async` there.
 - `isJsonObject` / `getJsonMember` — test a decoded JSON value for object-ness and read a member by
-  name (`dict` on Python, plain object on JS).
+  name (`dict` on Python, plain object on JS, an Erlang `map` on BEAM). On BEAM the decoded map is
+  keyed by the mangled record-field atom, not the F# name, so `getJsonMember` first maps the
+  reflection name through `toWireKey` (a reproduction of Fable's `sanitizeFieldName`: snake_case,
+  lowercased, trailing `_` for lowercase-first names). See the Fable follow-up gap below.
 
 Argument reconstruction itself (`RemotingHelpers.convertJsonValue`) is shared and recursive: it
 rebuilds records field-by-field via `FSharpValue.MakeRecord` and recurses through nested records and
@@ -99,22 +103,29 @@ replaces that default with an `exn -> HttpHandler`. The handler-exception path u
 rather than `try/with` around a `let!`, which is the construct Fable compiles consistently.
 
 Note the **JSON wire format is not identical across backends**: Fable lowercases record field names
-on Python (`{"description": ...}`) but preserves them on JS (`{"Description": ...}`), so a JS client
-and a Python server do not currently interoperate. Tests build expectations via `serialize` rather
+on Python (`{"description": ...}`) and snake_case-lowercases them on BEAM (`{"description": ...}`,
+`{"first_name": ...}`) but preserves them on JS (`{"Description": ...}`), so a JS client and a
+Python/BEAM server do not currently interoperate. Tests build expectations via `serialize` rather
 than literals for this reason.
 
-**BEAM is blocked** on a Fable compiler bug: record construction keys the Erlang map with
-`sanitizeFieldName` (appends `_` for lowercase-first names) while reflection reports `erl_name` via
-`sanitizeErlangName` (strips trailing `_`). They disagree for exactly the camelCase fields an API
-contract uses, so `PropertyInfo.GetValue` fails with `{badkey,...}` and `FSharpValue.MakeRecord`
-silently builds a record the compiled accessors cannot read. Type-level reflection on BEAM is
-otherwise complete and matches Python/JS exactly. Written up in
-`../Fable/BEAM-RECORD-FIELD-NAME-MANGLING-PROMPT.md`.
+**BEAM was unblocked by Fable 5.13.0** (`fix(beam)` #4849 made reflection value access agree with
+record codegen — `PropertyInfo.GetValue` / `FSharpValue.MakeRecord` no longer `{badkey,...}`).
+Remoting now runs on all three targets. Two BEAM-specific notes remain:
+
+- Reflection reports the pristine F# field name, not the record-map key, so `getJsonMember` has to
+  reproduce `sanitizeFieldName` via `toWireKey` (see above). The remaining ask — expose the map key
+  through reflection, or serialize records on clean names — is written up as a follow-up in
+  `../Fable/BEAM-RECORD-FIELD-NAME-MANGLING-PROMPT.md`.
+- The BEAM test runner wraps the suites in `testSequenced` (`test/beam/Main.fs`): every remoting test
+  passes in isolation, but under Quill's default cross-suite concurrency on BEAM the body assertions
+  intermittently fail with a garbled diff. This is a Scriptorium/BEAM concurrency+rendering gap
+  (Scriptorium PRs #13/#15); revert to plain parallel `runTests` once they release — tracked in
+  issue #54.
 
 ### Build System
 
 - `Justfile` - Build targets (replaces the old FAKE-based Build.fs)
-- Uses Fable 5.12.0 for F# to Python, JavaScript and BEAM compilation
+- Uses Fable 5.13.0 for F# to Python, JavaScript and BEAM compilation
 - Uses uv for Python dependency management
 
 ### Compilation Flow
@@ -127,8 +138,8 @@ Tests (`test/`) -> compiled per target to `build/tests-py/`, `build/test-js/`, `
 One behavioral suite in `test/shared/` (`HandlerTests.fs`, `RoutingTests.fs`) is compiled into three
 per-target projects — `test/python`, `test/js`, `test/beam` — each supplying its own `TestContext.fs`
 (a `TestContext.create` factory building an isolated context without a real server) and a thin
-`Main.fs` entry point. `RemotingTests.fs` runs on Python and JS; BEAM is blocked on a Fable
-compiler bug (see the Remoting note below).
+`Main.fs` entry point. `RemotingTests.fs` runs on all three targets as of Fable 5.13.0 (see the
+Remoting note below for the two BEAM-specific caveats: `toWireKey` and the `testSequenced` runner).
 
 Tests are written with [Scriptorium](https://github.com/fable-hub/Scriptorium) — Quill for the test
 DSL and runner, Nib for assertions — both of which compile to all three targets. `test/shared/Helpers.fs`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,18 +109,29 @@ Python/BEAM server do not currently interoperate. Tests build expectations via `
 than literals for this reason.
 
 **BEAM was unblocked by Fable 5.13.0** (`fix(beam)` #4849 made reflection value access agree with
-record codegen — `PropertyInfo.GetValue` / `FSharpValue.MakeRecord` no longer `{badkey,...}`).
-Remoting now runs on all three targets. Two BEAM-specific notes remain:
+record *and union* codegen — `PropertyInfo.GetValue` / `FSharpValue.MakeRecord` / `MakeUnion` no
+longer `{badkey,...}`). Remoting now runs on all three targets. Two BEAM-specific notes remain:
 
-- Reflection reports the pristine F# field name, not the record-map key, so `getJsonMember` has to
-  reproduce `sanitizeFieldName` via `toWireKey` (see above). The remaining ask — expose the map key
-  through reflection, or serialize records on clean names — is written up as a follow-up in
+- Reflection reports the pristine F# field name, not the record-map key, so `getJsonMember`
+  reproduces `sanitizeFieldName` via `toWireKey` (see above). The Fable team **declined** to change
+  the BEAM reflection surface or wire format (neither is needed for reflection correctness), so
+  `toWireKey` is the **sanctioned** integration point — not a temporary shim to delete. `sanitizeFieldName`
+  is stable; if it ever changes, the wire key is treated as contract. Background in
   `../Fable/BEAM-RECORD-FIELD-NAME-MANGLING-PROMPT.md`.
 - The BEAM test runner wraps the suites in `testSequenced` (`test/beam/Main.fs`): every remoting test
   passes in isolation, but under Quill's default cross-suite concurrency on BEAM the body assertions
   intermittently fail with a garbled diff. This is a Scriptorium/BEAM concurrency+rendering gap
   (Scriptorium PRs #13/#15); revert to plain parallel `runTests` once they release — tracked in
   issue #54.
+
+**Python tripwire on the next `fable-library-py` bump.** The Fable team is fixing Python reflection to
+report the *pristine* F# field name (like BEAM) while keeping the snake_case runtime slot
+(`PYTHON-RECORD-REFLECTION-FIELD-NAME-PROMPT.md`). When that lands, `convertJsonValue`'s
+`getJsonMember value f.Name` on Python will look up `FirstName` against a wire still keyed
+`first_name` (`giraffeDefault` reads `__slots__`) → reconstruction breaks. On that bump, add a Python
+wire-key mapping mirroring BEAM's `toWireKey` (pristine → snake_case slot), or serialize on the
+pristine name. The Python remoting tests use single-word PascalCase fields, which mangle to
+themselves, so they will *not* catch it — add a multi-word field first.
 
 ### Build System
 

--- a/src/beam/Fable.Giraffe.Beam.fsproj
+++ b/src/beam/Fable.Giraffe.Beam.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="../HttpContextExtensions.fs" Link="HttpContextExtensions.fs" />
     <Compile Include="../Core.fs" Link="Core.fs" />
     <Compile Include="../Routing.fs" Link="Routing.fs" />
+    <Compile Include="../Remoting.fs" Link="Remoting.fs" />
     <Compile Include="../Negotiation.fs" Link="Negotiation.fs" />
     <Compile Include="../HttpHandler.fs" Link="HttpHandler.fs" />
     <Compile Include="../HttpStatusCodeHandlers.fs" Link="HttpStatusCodeHandlers.fs" />

--- a/src/beam/HttpContext.fs
+++ b/src/beam/HttpContext.fs
@@ -10,6 +10,17 @@ open Fable.Beam.Cowboy.CowboyReq
 
 module CowboyReq = Fable.Beam.Cowboy.CowboyReq
 
+/// A body pre-buffered into the request map under `giraffe_body`. The in-process test harness
+/// seeds it there because it has no live socket for `cowboy_req:read_body` to stream from; real
+/// Cowboy requests never carry this key, so production always streams.
+module private BufferedBody =
+
+    [<Emit("maps:is_key(giraffe_body, $0)")>]
+    let has (req: Req) : bool = nativeOnly
+
+    [<Emit("maps:get(giraffe_body, $0)")>]
+    let get (req: Req) : string = nativeOnly
+
 /// HTTP request backed by a Cowboy request object.
 type HttpRequest(req: Req) =
     member x.Path: string option = CowboyReq.path req |> Some
@@ -24,8 +35,11 @@ type HttpRequest(req: Req) =
 
     member x.GetBodyAsync() =
         task {
-            let (_ok, body, _req2) = CowboyReq.readBody req
-            return body
+            if BufferedBody.has req then
+                return BufferedBody.get req
+            else
+                let (_ok, body, _req2) = CowboyReq.readBody req
+                return body
         }
 
     member x.Headers = HeaderDictionary()

--- a/src/beam/PlatformHelpers.fs
+++ b/src/beam/PlatformHelpers.fs
@@ -1,5 +1,9 @@
 namespace Fable.Giraffe
 
+open System
+open System.Text
+open System.Threading.Tasks
+
 open Fable.Core
 
 [<AutoOpen>]
@@ -24,3 +28,45 @@ module PlatformHelpers =
     /// `path` is absolute or relative to the node's working directory.
     [<Emit("element(2, file:read_file($0))")>]
     let readFileText (path: string) : string = nativeOnly
+
+    /// Start an `Async` and expose it as a `Task`. On BEAM the `task` computation
+    /// expression is a CPS alias for `Async` (see Helpers.toAsync), so the two share a
+    /// runtime representation and the bridge is the identity — no scheduler hop.
+    let startAsTask (computation: Async<'T>) : Task<'T> = unbox computation
+
+    /// True when a JSON-decoded value is an object rather than a scalar or an array.
+    /// `jsx:decode(_, [return_maps])` decodes JSON objects to Erlang maps, so this is
+    /// `is_map`. Drives the shared record-reconstruction recursion.
+    [<Emit("is_map($0)")>]
+    let isJsonObject (value: obj) : bool = nativeOnly
+
+    /// The wire key for a record field. Fable's BEAM backend keys record maps — and thus
+    /// `jsx:encode` output and `jsx:decode` input — by the Erlang atom form of the field
+    /// name: snake_case, lowercased, with a trailing `_` when the F# name starts lowercase
+    /// (Fable's `sanitizeFieldName`). Reflection still reports the pristine F# name via
+    /// `PropertyInfo.Name`, so we reproduce that mangling to find the decoded value.
+    /// e.g. `FirstName -> first_name`, `lastName -> last_name_`, `HTTPStatus -> h_t_t_p_status`.
+    let internal toWireKey (name: string) : string =
+        let sb = StringBuilder()
+
+        name
+        |> Seq.iteri (fun i c ->
+            if Char.IsUpper c then
+                if i > 0 then
+                    sb.Append('_') |> ignore
+
+                sb.Append(Char.ToLower c) |> ignore
+            else
+                sb.Append(c) |> ignore)
+
+        if name.Length > 0 && Char.IsLower name.[0] then
+            sb.Append('_') |> ignore
+
+        sb.ToString()
+
+    [<Emit("maps:get($1, $0, null)")>]
+    let private mapGet (value: obj) (key: string) : obj = nativeOnly
+
+    /// Read a member from a JSON-decoded object (an Erlang map) by its F# field name, or
+    /// `null` when absent. The name is mangled to the decoded map's key form first.
+    let getJsonMember (value: obj) (name: string) : obj = mapGet value (toWireKey name)

--- a/src/beam/PlatformHelpers.fs
+++ b/src/beam/PlatformHelpers.fs
@@ -46,6 +46,12 @@ module PlatformHelpers =
     /// (Fable's `sanitizeFieldName`). Reflection still reports the pristine F# name via
     /// `PropertyInfo.Name`, so we reproduce that mangling to find the decoded value.
     /// e.g. `FirstName -> first_name`, `lastName -> last_name_`, `HTTPStatus -> h_t_t_p_status`.
+    ///
+    /// This is the *sanctioned* Beam integration point, not a stopgap: the Fable team declined to
+    /// surface the map key through reflection or to key record JSON on clean names (neither is needed
+    /// for reflection correctness, which #4849 / Fable 5.13.0 already delivered). `sanitizeFieldName`
+    /// is not expected to change; if it ever does, the Beam wire key is treated as part of the
+    /// contract. So this reproduction stays — do not "simplify" it away against a future upstream fix.
     let internal toWireKey (name: string) : string =
         let sb = StringBuilder()
 

--- a/test/beam/Fable.Giraffe.Tests.Beam.fsproj
+++ b/test/beam/Fable.Giraffe.Tests.Beam.fsproj
@@ -11,6 +11,7 @@
     <Compile Include="TestContext.fs" />
     <Compile Include="../shared/HandlerTests.fs" />
     <Compile Include="../shared/RoutingTests.fs" />
+    <Compile Include="../shared/RemotingTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/beam/Main.fs
+++ b/test/beam/Main.fs
@@ -1,11 +1,19 @@
 module Fable.Giraffe.Tests.Main
 
 open type Scriptorium.Quill.Runner
+open type Scriptorium.Quill.Test
 
 // BEAM runner. Quill runs the suite synchronously here and calls `halt/1` with the exit code, so
-// `erl` returns non-zero when tests fail. Fable >= 5.8 namespaces generated BEAM modules and
-// emits a `main.erl` shim that dispatches to [<EntryPoint>], so using the entry point keeps the
-// runner findable across Fable versions. Remoting is Python-only.
+// `erl` returns non-zero when tests fail. Fable >= 5.8 namespaces generated BEAM modules and emits
+// a `main.erl` shim that dispatches to [<EntryPoint>], so the entry point keeps the runner findable
+// across Fable versions.
+//
+// The three suites are wrapped in `testSequenced` so they run one-suite-at-a-time rather than all
+// interleaved. Every remoting test passes on its own and the suite passes when run in isolation, but
+// under Quill's default cross-suite concurrency on BEAM the remoting body assertions intermittently
+// fail with a garbled diff (rendered as "1"). That is a Scriptorium/BEAM concurrency+rendering gap
+// tracked in Scriptorium PRs #13 (Quill 0.5.1 Unicode output) and #15 (Nib char-level diffs); once
+// those release, drop back to a plain parallel `runTests [ ...; RemotingTests.tests ]`. See #54.
 [<EntryPoint>]
 let main _ =
-    runTests [ HandlerTests.tests; RoutingTests.tests ]
+    runTests [ testSequenced ("suite", [ HandlerTests.tests; RoutingTests.tests; RemotingTests.tests ]) ]

--- a/test/beam/TestContext.fs
+++ b/test/beam/TestContext.fs
@@ -5,15 +5,16 @@ open Fable.Beam.Cowboy.CowboyReq
 
 open Fable.Giraffe
 
-// BEAM/Cowboy-target test-context factory. The shared Handler/Routing suite never reads the
-// request body (only Remoting does, and that's Python-only), so a fake Cowboy Req *map* with
-// method/path/scheme satisfies the cowboy_req:method/path/scheme lookups without a live socket;
-// the response is read straight off HttpResponse.Body. A factory (not a subclass) because
-// Fable.Beam inheritance does not carry the base HttpContext's fields (e.g. field_response).
+// BEAM/Cowboy-target test-context factory. A fake Cowboy Req *map* with method/path/scheme
+// satisfies the cowboy_req:method/path/scheme lookups without a live socket; the response is read
+// straight off HttpResponse.Body. The request body is pre-buffered under `giraffe_body` (there is
+// no socket for cowboy_req:read_body to stream from) — HttpRequest.GetBodyAsync reads it there.
+// A factory (not a subclass) because Fable.Beam inheritance does not carry the base HttpContext's
+// fields (e.g. field_response).
 module private BeamFakes =
 
-    [<Emit("#{method => $0, path => $1, scheme => <<\"http\">>}")>]
-    let makeReq (method: string) (path: string) : Req = nativeOnly
+    [<Emit("#{method => $0, path => $1, scheme => <<\"http\">>, giraffe_body => $2}")>]
+    let makeReq (method: string) (path: string) (body: string) : Req = nativeOnly
 
 
 type TestContext =
@@ -23,5 +24,6 @@ type TestContext =
         : HttpContext * (unit -> byte[]) =
         let _method = defaultArg method "GET"
         let _path = defaultArg path "/"
-        let ctx = HttpContext(BeamFakes.makeReq _method _path)
+        let _body = defaultArg body ""
+        let ctx = HttpContext(BeamFakes.makeReq _method _path _body)
         ctx, (fun () -> ctx.Response.Body)


### PR DESCRIPTION
## Summary

Fable **5.13.0** fixes the Beam record-field mangling bug (`fix(beam)` #4849 — reflection value access now agrees with record codegen, so `PropertyInfo.GetValue` / `FSharpValue.MakeRecord` no longer return `{badkey,...}`). That was the sole blocker, so `src/Remoting.fs` now compiles and runs on **all three targets** (Python, JS, BEAM).

## Changes

- **Bump the `fable` tool to 5.13.0.** Python/JS/BEAM all stay green against the existing library pins.
- **Three BEAM `PlatformHelpers` seams:**
  - `startAsTask` — identity `unbox` (on BEAM `task` is a CPS alias for `Async`).
  - `isJsonObject` — `is_map` (jsx decodes JSON objects to Erlang maps).
  - `getJsonMember` — maps the reflection field name through `toWireKey`, a reproduction of Fable's `sanitizeFieldName`. Reflection reports the pristine F# name (`Customer`) while the decoded jsx map is keyed by the mangled atom (`customer`, `lastName` → `last_name_`, `HTTPStatus` → `h_t_t_p_status`).
- **`HttpContext.GetBodyAsync`** reads a pre-buffered `giraffe_body` from the request map when present. The in-process test harness seeds it there because a fake Cowboy req has no live socket for `cowboy_req:read_body`; real reqs never carry the key, so production always streams.
- Wire `Remoting.fs` into the BEAM library fsproj and `RemotingTests.fs` into the BEAM test project.

## Testing

All three targets green: **Python 55 · JS 53 (+2 skipped) · BEAM 47 (+8 skipped)** — the BEAM run now includes 10 remoting tests.

The remoting implementation was verified correct under every execution model — isolation, `Async.Parallel`, `Async.StartChild` (Quill's spawn model), the exact `toAsync (task {…})` + `assertThat` shape, 40-way concurrency, and the remoting suite run alone (10/10).

## Known caveat (temporary)

The remoting tests fail **only** under Quill's default cross-suite concurrency on BEAM — the body assertions intermittently render a garbled diff (`"1"`). This is a Scriptorium/BEAM concurrency+rendering gap (Scriptorium PRs #13 / #15, not yet released), not a remoting bug. Worked around by wrapping the suites in `testSequenced` in the BEAM runner only (`test/beam/Main.fs`); Python/JS are untouched. **Revert to plain parallel `runTests` once Scriptorium ships — tracked in #54.**

## Follow-up recorded

A residual Fable gap is written up in `../Fable/BEAM-RECORD-FIELD-NAME-MANGLING-PROMPT.md` (updated to mark #4849 resolved): reflection exposes the F# field name but not the record-map key, forcing `toWireKey` to reimplement a compiler-internal naming rule. Ask: expose the map key via reflection, or serialize records on clean names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)