### PR TITLE
ci: use NuGet trusted publishing for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: "github.event_name == 'workflow_dispatch' || startsWith(github.event.head_commit.message, 'chore: release ')"
+    # Job-scoped permissions: only Release needs an OIDC token, so id-token: write
+    # is granted here rather than at the top level. contents: write is for the GitHub Release.
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -87,8 +92,16 @@ jobs:
       - name: Pack NuGet
         run: just pack-version ${{ steps.version.outputs.version }}
 
+      # Trusted Publishing: exchange the job's OIDC token for a short-lived (1 hour)
+      # nuget.org API key. Requested right before the push so it doesn't expire.
+      - name: NuGet login (OIDC -> temp API key)
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
       - name: Push NuGet
-        run: dotnet nuget push 'src/**/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push 'src/**/Release/*.nupkg' -s https://api.nuget.org/v3/index.json -k ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
 
       - name: Create GitHub Release
         run: gh release create ${{ steps.version.outputs.tag }} --title "${{ steps.version.outputs.version }}" --generate-notes || echo "Release already exists"


### PR DESCRIPTION
## What

Switches the Release job in `publish.yml` from a long-lived `NUGET_API_KEY` secret to OIDC-based [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing).

## Changes

- Grant `id-token: write` **scoped to the Release job only** (least privilege — the ShipIt PR job keeps the top-level permissions and gets no token-issuance rights).
- Add a `NuGet/login@v1` step that exchanges the job's OIDC token for a short-lived (1 hour) API key, placed right before the push so it can't expire.
- Push with the minted key (`steps.nuget-login.outputs.NUGET_API_KEY`) instead of `secrets.NUGET_API_KEY`.

## Prerequisites (already done)

- ✅ Trusted publishing policy created on nuget.org — owner `dbrattli`, repo `Fable.Giraffe`, workflow `publish.yml`, no environment.
- ✅ `NUGET_USER` repo secret added (nuget.org profile name).

## Follow-up

- After the **first successful trusted-publish**, delete the now-unused `NUGET_API_KEY` repo secret.
- Since this is a public repo, the policy activates permanently on first publish (the 7-day pending window only applies to private repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)