### PR TITLE
feat: add reproducible cross-target benchmark harness

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -101,3 +101,8 @@ pack-version version:
 # Run EasyBuild.ShipIt for release management (opens/updates the release PR)
 shipit *args:
     dotnet shipit --skip-invalid-commit {{args}}
+
+# Benchmark a /ping handler across targets, all with logging off (oha, 10k req / 100 conn).
+# Pass targets to limit the run, e.g. `just bench python js`. Requires oha on PATH.
+bench *targets:
+    FABLE="{{fable}}" perf/bench.sh {{targets}}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ once in F# and run it on three runtimes:
 | JavaScript | Node.js | built-in `node:http`, or mounted as `connect`/`express` middleware |
 | Erlang/BEAM | OTP | Cowboy |
 
+Fable.Giraffe's major version tracks the Fable compiler it targets: the 5.x
+line is built with and requires Fable 5.
+
 ## Example
 
 The handler pipeline is identical on every target:
@@ -102,14 +105,25 @@ There is no pure-.NET behavioral run: `src` is Fable-only bindings, so
 
 ## Benchmarks
 
-Simple `/ping` endpoint returning "pong", 10,000 requests with 100 concurrent
-connections (oha):
+An identical `/ping` handler (returns `pong`) on every target, driven with
+[oha](https://github.com/hatoo/oha): 10,000 requests at 100 concurrent
+connections over loopback, with **no per-request logging on any target**. The
+.NET row is the original Giraffe on ASP.NET Core / Kestrel, included as a
+reference point.
 
-| Metric | BEAM | .NET | Python |
+| Target | Requests/sec | Avg latency | P99 latency |
 |---|---|---|---|
-| Requests/sec | 124,256 | 70,375 | 4,006 |
-| Avg latency | 0.79 ms | 1.40 ms | 24.9 ms |
-| P99 latency | 2.49 ms | 3.50 ms | 34.2 ms |
+| .NET (reference) | ~321,000 | 0.29 ms | 1.33 ms |
+| Erlang/BEAM (Cowboy) | ~217,000 | 0.44 ms | 1.71 ms |
+| JavaScript (Node) | ~63,000 | 1.56 ms | 3.24 ms |
+| Python (uvicorn, 1 worker) | ~14,000 | 6.95 ms | 15.22 ms |
 
-BEAM: Erlang/OTP 28, Cowboy. .NET: Giraffe on ASP.NET Core. Python: uvicorn, 1 worker.
-The JavaScript/Node target has not been benchmarked yet.
+These numbers are machine-dependent and only meaningful relative to one another;
+throughput at the top of the table is noisy because the framework outruns the
+loopback/oha harness driving it. The harness lives in [`perf/`](perf/) — reproduce
+with `just bench` (or `just bench python js` for a subset).
+
+Every target must share the same logging configuration for the comparison to
+mean anything: an earlier version of this table ran with logging enabled on .NET
+but not BEAM, which made .NET look slower than BEAM. The current run turns
+per-request logging off everywhere.

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,49 @@
+# perf
+
+A fair, reproducible throughput benchmark for Fable.Giraffe across all targets.
+
+Each target serves an **identical `/ping` handler** (`route "/ping" |> text "pong"`)
+with **no per-request logging**, and [oha](https://github.com/hatoo/oha) drives the
+same load at each. The apps are deliberately minimal so the numbers reflect the
+framework, not application code.
+
+## Running
+
+```console
+just bench             # all targets: dotnet python js beam
+just bench python js   # a subset
+```
+
+Or call the script directly:
+
+```console
+perf/bench.sh                          # all targets
+REQUESTS=20000 CONNECTIONS=200 perf/bench.sh dotnet beam
+```
+
+Requires [oha](https://github.com/hatoo/oha) on `PATH`, plus the per-target
+toolchains already listed in the top-level README (uv, Node, Erlang/rebar3, .NET).
+
+## Layout
+
+| Path | Target | How it's served |
+|---|---|---|
+| `dotnet/` | Real Giraffe on ASP.NET Core (reference) | Kestrel, `dotnet` (port 8083) |
+| `python/` | `Fable.Giraffe.Python` | uvicorn, 1 worker (port 8081) |
+| `js/`     | `Fable.Giraffe.Js`     | `node:http` (port 8082) |
+| `beam/`   | `Fable.Giraffe.Beam`   | Cowboy (port 8084) |
+
+`bench.sh` builds each target, boots it in its own process group, waits for
+`/ping` to answer, warms up, runs oha, then tears the server down.
+
+## Why "no logging" matters
+
+The Python and JS middleware emit a per-request access log **only when
+`LogLevel.Debug` is enabled** (see `src/python/Middleware.fs`). The example apps
+in `app/` turn that on deliberately; the BEAM app configures no logger at all. A
+benchmark that left those settings as-is would compare a logging server against a
+non-logging one. The perf apps here all pin logging off (`Warning` minimum level
+on the Fable targets, `ClearProviders()` on .NET) so the comparison is like-for-like.
+
+Standard framework-throughput practice (e.g. TechEmpower) is to benchmark without
+per-request logging, which is what this harness does.

--- a/perf/beam/Perf.Beam.fsproj
+++ b/perf/beam/Perf.Beam.fsproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Fable.Core" Version="5.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\beam\Fable.Giraffe.Beam.fsproj" />
+  </ItemGroup>
+</Project>

--- a/perf/beam/Program.fs
+++ b/perf/beam/Program.fs
@@ -1,0 +1,19 @@
+module Program
+
+open Fable.Giraffe
+open Fable.Giraffe.Pipelines
+
+type Model = { Name: string; Age: int }
+
+let webApp =
+    choose [
+        route "/ping" |> HttpHandler.text "pong"
+        route "/json" |> HttpHandler.json { Name = "Dag"; Age = 53 }
+    ]
+
+// BEAM configures no logging provider, so the Debug-gated access log never
+// fires — already the fair baseline the other targets are matched to.
+let start () =
+    WebHostBuilder()
+        .Configure(fun app -> app.UseGiraffe(webApp))
+        .Build(8084)

--- a/perf/bench.sh
+++ b/perf/bench.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# Fair, reproducible throughput benchmark for Fable.Giraffe across every target.
+#
+# Each target serves an identical `/ping` handler with NO per-request logging
+# (the Fable access log is Debug-gated and left off; the .NET reference clears
+# its providers). oha then drives the same load at every target.
+#
+# Usage:
+#   perf/bench.sh                    # all targets: dotnet python js beam
+#   perf/bench.sh python js          # a subset
+#   REQUESTS=20000 CONNECTIONS=200 perf/bench.sh dotnet
+#
+# Env:
+#   REQUESTS     total requests   (default 10000)
+#   CONNECTIONS  concurrency      (default 100)
+#   FABLE        fable command    (default "dotnet fable")
+set -uo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO"
+
+REQUESTS="${REQUESTS:-10000}"
+CONNECTIONS="${CONNECTIONS:-100}"
+FABLE="${FABLE:-dotnet fable}"
+
+port_of() { case "$1" in dotnet) echo 8083 ;; python) echo 8081 ;; js) echo 8082 ;; beam) echo 8084 ;; esac; }
+
+SERVER_PGID=""
+LOG=/tmp/perf-server.log
+
+# Run a command in its own process group so the whole tree can be torn down.
+start_bg() {
+    setsid bash -c "$1" >"$LOG" 2>&1 &
+    SERVER_PGID=$!
+}
+
+stop_bg() {
+    [ -n "$SERVER_PGID" ] || return 0
+    kill -TERM -"$SERVER_PGID" 2>/dev/null
+    wait "$SERVER_PGID" 2>/dev/null
+    SERVER_PGID=""
+}
+
+trap stop_bg EXIT
+
+wait_ready() {
+    local port="$1" i
+    for i in $(seq 1 150); do
+        curl -sf "http://127.0.0.1:$port/ping" >/dev/null 2>&1 && return 0
+        # Bail early if the server process already died.
+        kill -0 -"$SERVER_PGID" 2>/dev/null || { echo "  !! server exited during startup"; return 1; }
+        sleep 0.2
+    done
+    echo "  !! server on port $port never answered /ping"
+    return 1
+}
+
+# --- per-target build (foreground) + serve command ---------------------------
+
+build_dotnet() { dotnet build -c Release "$REPO/perf/dotnet" >/dev/null; }
+serve_dotnet() { echo "exec dotnet '$REPO/perf/dotnet/bin/Release/net8.0/Perf.Dotnet.dll'"; }
+
+build_python() { $FABLE perf/python --exclude Fable.Core --lang Python >/dev/null; }
+serve_python() { echo "cd '$REPO/perf/python' && exec uv run --project '$REPO' uvicorn program:app --port 8081 --workers 1 --log-level error"; }
+
+build_js() {
+    npm install >/dev/null 2>&1
+    $FABLE perf/js --exclude Fable.Core --lang javascript --outDir build/perf-js >/dev/null
+    echo '{"type":"module"}' >build/perf-js/package.json
+}
+serve_js() { echo "exec node '$REPO/build/perf-js/Program.js'"; }
+
+build_beam() {
+    # build-beam does clean-beam + compiles the library into build/apps/giraffe.
+    just build-beam >/dev/null 2>&1
+    # Compile the perf app alongside it.
+    $FABLE perf/beam --exclude Fable.Core --lang beam --outDir build/apps/giraffe_perf >/dev/null
+    # The repo rebar.config only declares the example app; point rebar at the perf app instead.
+    cat >build/rebar.config <<'EOF'
+{erl_opts, [no_debug_info, nowarn_unused_result]}.
+{deps, [{cowboy, "2.12.0"}, jsx]}.
+{project_app_dirs, [
+    "apps/giraffe", "apps/giraffe/fable_modules/*",
+    "apps/giraffe_perf", "apps/giraffe_perf/fable_modules/*"
+]}.
+EOF
+    (cd build && rebar3 compile >/dev/null 2>&1)
+}
+serve_beam() {
+    echo "cd '$REPO' && exec erl -pa build/_build/default/lib/*/ebin -noshell \
+        -eval 'application:ensure_all_started(cowboy)' \
+        -eval 'perf_beam_program:start()' \
+        -eval 'receive stop -> ok end'"
+}
+
+# --- driver ------------------------------------------------------------------
+
+run_one() {
+    local target="$1" port
+    port="$(port_of "$target")"
+    echo "=================================================================="
+    echo " $target  (port $port, $REQUESTS req / $CONNECTIONS conn, logging off)"
+    echo "=================================================================="
+
+    echo "-- building..."
+    if ! "build_$target"; then
+        echo "  !! build failed; see output above. skipping $target."
+        return 1
+    fi
+
+    echo "-- starting server..."
+    start_bg "$(serve_$target)"
+
+    if ! wait_ready "$port"; then
+        echo "  --- server log (tail) ---"
+        tail -n 20 "$LOG"
+        stop_bg
+        return 1
+    fi
+
+    echo "-- warming up..."
+    oha -n 1000 -c "$CONNECTIONS" --no-tui "http://127.0.0.1:$port/ping" >/dev/null 2>&1
+
+    echo "-- benchmarking..."
+    oha -n "$REQUESTS" -c "$CONNECTIONS" --no-tui "http://127.0.0.1:$port/ping" \
+        | grep -E "Success rate|Requests/sec|Total:|Slowest:|Fastest:|Average:|^\s+50\.00%|^\s+99\.00%" \
+        | sed 's/^/   /'
+
+    stop_bg
+    echo
+}
+
+TARGETS=("$@")
+[ ${#TARGETS[@]} -eq 0 ] && TARGETS=(dotnet python js beam)
+
+for t in "${TARGETS[@]}"; do
+    run_one "$t" || true
+done

--- a/perf/dotnet/Perf.Dotnet.fsproj
+++ b/perf/dotnet/Perf.Dotnet.fsproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Giraffe" Version="8.2.0" />
+  </ItemGroup>
+</Project>

--- a/perf/dotnet/Program.fs
+++ b/perf/dotnet/Program.fs
@@ -1,0 +1,30 @@
+module Program
+
+open Microsoft.AspNetCore.Builder
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.Extensions.Logging
+open Giraffe
+
+// The real Giraffe running on ASP.NET Core / Kestrel — the reference point the
+// Fable targets are measured against. The handler pipeline mirrors the Fable
+// perf apps exactly.
+let webApp =
+    choose [
+        route "/ping" >=> text "pong"
+        route "/json" >=> json {| Name = "Dag"; Age = 53 |}
+    ]
+
+[<EntryPoint>]
+let main args =
+    let builder = WebApplication.CreateBuilder(args)
+    builder.Services.AddGiraffe() |> ignore
+
+    // Fair baseline: no per-request logging, matching the Fable targets (whose
+    // access log is Debug-gated and left off here). Clearing providers also drops
+    // Kestrel/hosting startup chatter.
+    builder.Logging.ClearProviders().SetMinimumLevel(LogLevel.Warning) |> ignore
+
+    let app = builder.Build()
+    app.UseGiraffe(webApp)
+    app.Run("http://127.0.0.1:8083")
+    0

--- a/perf/js/Perf.Js.fsproj
+++ b/perf/js/Perf.Js.fsproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Fable.Core" Version="5.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\js\Fable.Giraffe.Js.fsproj" />
+  </ItemGroup>
+</Project>

--- a/perf/js/Program.fs
+++ b/perf/js/Program.fs
@@ -1,0 +1,19 @@
+module Program
+
+open Fable.Giraffe
+open Fable.Giraffe.Pipelines
+open Fable.Logging
+
+type Model = { Name: string; Age: int }
+
+let webApp =
+    choose
+        [ route "/ping" |> HttpHandler.text "pong"
+          route "/json" |> HttpHandler.json { Name = "Dag"; Age = 53 } ]
+
+// No per-request logging: a Warning minimum level keeps the Debug-gated access
+// log from firing. The example app in app/js deliberately runs at Debug.
+WebHostBuilder()
+    .ConfigureLogging(fun builder -> builder.SetMinimumLevel(LogLevel.Warning))
+    .Configure(fun app -> app.UseGiraffe(webApp))
+    .Run(8082)

--- a/perf/python/.gitignore
+++ b/perf/python/.gitignore
@@ -1,0 +1,4 @@
+# Fable-generated Python output (compiled in place by perf/bench.sh)
+*.py
+fable_modules/
+__pycache__/

--- a/perf/python/Perf.Python.fsproj
+++ b/perf/python/Perf.Python.fsproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Fable.Core" Version="5.2.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\python\Fable.Giraffe.Python.fsproj" />
+  </ItemGroup>
+</Project>

--- a/perf/python/Program.fs
+++ b/perf/python/Program.fs
@@ -1,0 +1,22 @@
+module Program
+
+open Fable.Giraffe
+open Fable.Giraffe.Pipelines
+open Fable.Logging
+
+type Model = { Name: string; Age: int }
+
+let webApp =
+    choose [
+        route "/ping" |> HttpHandler.text "pong"
+        route "/json" |> HttpHandler.json { Name = "Dag"; Age = 53 }
+    ]
+
+// No per-request logging: a Warning minimum level keeps the middleware's
+// Debug-gated access log (src/python/Middleware.fs) from ever firing. This is
+// the fair baseline — the example app in app/ deliberately runs at Debug.
+let app =
+    WebHostBuilder()
+        .ConfigureLogging(fun builder -> builder.SetMinimumLevel(LogLevel.Warning))
+        .Configure(fun app -> app.UseGiraffe(webApp))
+        .Build()


### PR DESCRIPTION
## Why

The README benchmark numbers were hand-run once, not reproducible from any committed harness, and **unfair**: the `.NET` row ran with logging enabled while BEAM had none, which made .NET look *slower* than BEAM. The Python/JS middleware only emits a per-request access log when `LogLevel.Debug` is enabled (see `src/python/Middleware.fs`), and the BEAM app configures no logger — so any comparison has to pin logging identically to mean anything.

## What

A self-contained, reproducible harness in [`perf/`](perf/) that serves an **identical `/ping` handler** on every target with **per-request logging off**, and drives each with [oha](https://github.com/hatoo/oha) (10k requests / 100 connections):

| Path | Target | Served via |
|---|---|---|
| `perf/dotnet/` | Real Giraffe on ASP.NET Core (reference) | Kestrel |
| `perf/python/` | `Fable.Giraffe.Python` | uvicorn, 1 worker |
| `perf/js/`     | `Fable.Giraffe.Js`     | `node:http` |
| `perf/beam/`   | `Fable.Giraffe.Beam`   | Cowboy |

Run with `just bench` (all targets) or `just bench python js` (a subset). `perf/bench.sh` builds each target, boots it in its own process group, waits for `/ping`, warms up, runs oha, then tears it down.

## Fair results (logging off everywhere)

| Target | Requests/sec | Avg latency | P99 latency |
|---|---|---|---|
| .NET (reference) | ~321,000 | 0.29 ms | 1.33 ms |
| Erlang/BEAM | ~217,000 | 0.44 ms | 1.71 ms |
| JavaScript/Node | ~63,000 | 1.56 ms | 3.24 ms |
| Python | ~14,000 | 6.95 ms | 15.22 ms |

The ordering flips relative to the old table — **.NET is fastest**, not BEAM — because the old .NET figure was paying for logging the others weren't. Numbers are machine-dependent and noisy at the top (the framework outruns the loopback/oha driver); the relative ordering is the meaningful part.

## Also

- Rewrites the README benchmark table + adds a note recording the original methodology flaw so it doesn't recur.
- Documents the harness in `perf/README.md`.
- Adds a one-line README note that the 5.x line tracks Fable 5.

## Notes

- The `.NET` app references `Giraffe` 8.2.0 from NuGet; `just bench dotnet` restores it on first run.
- Generated Fable output (Python compiled in place, JS/BEAM to `build/`) is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)