### PR TITLE
perf: trim per-request overhead on the Python hot path

### DIFF
--- a/src/Core.fs
+++ b/src/Core.fs
@@ -85,12 +85,12 @@ module Core =
     /// <returns>A Giraffe <see cref="HttpHandler"/> function which can be composed into a bigger web application.</returns>
     let private httpVerb (validate: string -> bool) : HttpHandler =
         fun (next: HttpFunc) (ctx: HttpContext) ->
-            task {
-                if validate ctx.Request.Method then
-                    return! next ctx
-                else
-                    return! skipPipeline ()
-            }
+            // Return the existing Task directly; a `task { return! ... }` wrapper here is
+            // pure per-request overhead (builder/Delay/Run) since neither branch awaits.
+            if validate ctx.Request.Method then
+                next ctx
+            else
+                skipPipeline ()
 
     let GET: HttpHandler = httpVerb HttpMethods.IsGet
     let POST: HttpHandler = httpVerb HttpMethods.IsPost

--- a/src/Routing.fs
+++ b/src/Routing.fs
@@ -46,12 +46,13 @@ module SubRouting =
 module Routing =
     let route (path: string) : HttpHandler =
         fun (next: HttpFunc) (ctx: HttpContext) ->
-            task {
-                if (SubRouting.getNextPartOfPath ctx).Equals path then
-                    return! next ctx
-                else
-                    return! skipPipeline ()
-            }
+            // Both branches already yield an HttpFuncResult (Task), so return it directly
+            // rather than wrapping in a `task { return! ... }` — that CE compiles to a
+            // builder/Delay/Run layer on every request for no behavioural gain.
+            if (SubRouting.getNextPartOfPath ctx).Equals path then
+                next ctx
+            else
+                skipPipeline ()
 
     /// <summary>
     /// Filters an incoming HTTP request based on the request path (case insensitive).

--- a/src/python/HttpContext.fs
+++ b/src/python/HttpContext.fs
@@ -51,11 +51,19 @@ type HttpRequest(scope: Scope, receive: ReceiveAsync) =
 type HttpResponse(send: SendAsync) =
     let mutable statusCode = None
 
+    // Build the ASGI event dicts directly. `Dictionary(dict [ ... ])` compiles to
+    // make_dict(make_dict(...)) — two dict allocations each, per request — because the
+    // inner `dict [ ... ]` is materialised only to be copied into the outer Dictionary.
     let responseStart =
-        Dictionary<string, obj>(dict [ ("type", "http.response.start" :> obj); ("headers", ResizeArray<_>()) ])
+        let d = Dictionary<string, obj>()
+        d["type"] <- "http.response.start"
+        d["headers"] <- ResizeArray<string * obj>()
+        d
 
     let responseBody =
-        Dictionary<string, obj>(dict [ ("type", "http.response.body" :> obj) ])
+        let d = Dictionary<string, obj>()
+        d["type"] <- "http.response.body"
+        d
 
     member x.Headers =
         let tuples = responseStart["headers"] :?> ResizeArray<string * obj>

--- a/src/python/Middleware.fs
+++ b/src/python/Middleware.fs
@@ -17,11 +17,14 @@ type GiraffeMiddleware(app: ASGIApp, handler: HttpHandler, loggerFactory: ILogge
             let ctx = HttpContext(scope, receive, send)
 
             if ctx.Request.Protocol = "http" then
-                let start = Diagnostics.Stopwatch.GetTimestamp()
+                // Only read the clock when the access log will actually be emitted;
+                // otherwise this is a per-request syscall on the hot path for nothing.
+                let logging = logger.IsEnabled LogLevel.Debug
+                let start = if logging then Diagnostics.Stopwatch.GetTimestamp() else 0L
 
                 let! result = func ctx
 
-                if logger.IsEnabled LogLevel.Debug then
+                if logging then
                     let stop = Diagnostics.Stopwatch.GetTimestamp()
 
                     let elapsedMs = (double (stop - start)) * 1000.0 / freq


### PR DESCRIPTION
Found by reading the Fable-generated Python for a `/ping` request and correlating it with the F# source. Four low-risk fixes, all measured and regression-tested.

## Changes

1. **`route` / `httpVerb` — drop the no-op `task { }` CE** (`src/Routing.fs`, `src/Core.fs`)
   Both were `fun next ctx -> task { if cond then return! next ctx else return! skipPipeline () }`. Since both branches already yield an `HttpFuncResult` (a `Task`), the CE just adds a `builder`/`Delay`/`Run` trampoline layer **per request**. Returning the `Task` directly removes it. `route` runs on every request. This is **shared** code, so JS and BEAM get the same simplification (and it reads cleaner).

   Generated Python before/after:
   ```python
   # before: builder_0040 = task(); ... return await builder_0040.Run(builder_0040.Delay(_arrow127))
   # after:  if SubRouting_getNextPartOfPath(ctx) == path: return await next_1(ctx) else: ...
   ```

2. **`HttpResponse` — build the ASGI dicts directly** (`src/python/HttpContext.fs`)
   `Dictionary<string,obj>(dict [ ... ])` compiled to `make_dict(make_dict(...))` — the inner `dict [ ... ]` is materialised only to be copied into the outer `Dictionary`. Two dict allocations each, per request, for both `responseStart` and `responseBody`. Now a single dict + key assignments.

3. **Middleware — read the clock only when logging** (`src/python/Middleware.fs`)
   `Stopwatch.GetTimestamp()` ran on every request even with the access log disabled (the common production case). Now gated on `logger.IsEnabled Debug`, saving a `clock_gettime` syscall per request.

## Measurement

Python `/ping`, `just bench python`, 10k req / 100 conn, 5 runs each:

| | req/s (range) |
|---|---|
| baseline (main) | ~14,559 (14,356–14,716) |
| this PR | ~14,882 (14,686–15,036) |

**~+2.2%**, small but consistent (the optimized minimum nearly exceeds the baseline maximum). No regressions: Python 55 passed, JS 53 passed + 2 skipped, BEAM 47 passed + 8 skipped — unchanged from main.

## Why the gain is modest — and where the real lever is (upstream)

The per-`/ping` hot path instantiates ~6–7 separate `task {}` computation expressions (middleware invoke, the try/with wrapper, `chooseHttpFunc`, `route`, `WriteBytesAsync`, `WriteAsync`), each compiling to a builder + `Delay`/`Run`/`Bind`/`Combine` with several closure allocations. On top of that, `int32` boxing (`int32(200)`, `int32.TWO`, `int32(len(bytes))`, status/length comparisons) is pervasive. These two — the **fable-library-py `task` builder** and **`int32` wrapping** — dominate the Python cost and are **upstream** concerns in `fable-library-py` / the Fable compiler, not something this PR can remove. This PR removes what can be removed cleanly in-repo.

Possible in-repo follow-ups (not in this PR, higher risk): hand-write `chooseHttpFunc` / `WriteAsync` / `WriteBytesAsync` as plain `async` functions to shed more CE layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)