### PR TITLE
refactor: compose the JS handler pipeline once; correct uncurrying comment

### DIFF
--- a/src/js/Server.fs
+++ b/src/js/Server.fs
@@ -77,19 +77,24 @@ module Server =
 
             go stages)
 
-    /// Run the Giraffe handler for a single request. If the pipeline never wrote
-    /// a response, `onUnhandled` decides what happens (call the host's `next`, or
-    /// answer 404 in standalone mode).
+    /// Run the pre-composed Giraffe pipeline for a single request. If it never
+    /// wrote a response, `onUnhandled` decides what happens (call the host's
+    /// `next`, or answer 404 in standalone mode).
     ///
-    /// The handler is applied fully here — `handler earlyReturn ctx` — rather
-    /// than pre-applied to a stored `HttpFunc`. `HttpHandler = HttpFunc ->
-    /// HttpFunc` is Fable's ambiguous "function returning a function" case (see
-    /// fable.io "automatic uncurrying"): a *partial* application stored as a
-    /// value gets mis-normalized (via `curry2`) so it returns a function instead
-    /// of running. A full, typed application is the shape Fable uncurries
-    /// consistently, independent of how the handler was composed.
+    /// `func` is `handler earlyReturn`, composed ONCE by the caller (`run` /
+    /// `toMiddleware`) rather than per request — the same shape the Python and
+    /// BEAM backends store. Storing the partial application as a typed `HttpFunc`
+    /// works: Fable emits `curry2(handler)(earlyReturn)`, which yields a correct
+    /// one-argument function, so `func ctx` runs the pipeline. An earlier comment
+    /// here claimed this mis-normalized into "a function that returns a function";
+    /// that does not reproduce on Fable 5.13 — verified against /ping and /json.
+    ///
+    /// This is for cross-backend consistency, not speed: unlike BEAM (where
+    /// composing per request cost ~5%), V8 already inlines the per-request
+    /// composition away, and the `curry2` wrapper roughly offsets it — measured
+    /// flat. Kept composed-once so all three backends read the same.
     let private dispatch
-        (handler: HttpHandler)
+        (func: HttpFunc)
         (services: ServiceCollection)
         (req: IncomingMessage)
         (res: ServerResponse)
@@ -99,7 +104,7 @@ module Server =
 
         (task {
             try
-                let! _ = handler earlyReturn ctx
+                let! _ = func ctx
 
                 if not ctx.Response.HasStarted then
                     onUnhandled ()
@@ -122,14 +127,16 @@ module Server =
         (services: ServiceCollection)
         : Func<IncomingMessage, ServerResponse, (unit -> unit), unit> =
         let statics = staticPipeline mounts
+        let func: HttpFunc = handler earlyReturn
 
-        Func<_, _, _, _>(fun req res next -> statics.Invoke(req, res, (fun () -> dispatch handler services req res next)))
+        Func<_, _, _, _>(fun req res next -> statics.Invoke(req, res, (fun () -> dispatch func services req res next)))
 
     /// Start a zero-framework `http` server driving the Giraffe handler. Configured static
     /// mounts (serve-static) are tried first; unmatched requests get a 404 (there is no outer
     /// host to fall through to).
     let run (mounts: (string * string) list) (handler: HttpHandler) (services: ServiceCollection) (port: int) : unit =
         let statics = staticPipeline mounts
+        let func: HttpFunc = handler earlyReturn
 
         let listener =
             Func<IncomingMessage, ServerResponse, unit>(fun req res ->
@@ -138,6 +145,6 @@ module Server =
                     res.setHeader ("content-type", "text/plain; charset=utf-8")
                     res.``end`` (box "Not Found")
 
-                statics.Invoke(req, res, (fun () -> dispatch handler services req res send404)))
+                statics.Invoke(req, res, (fun () -> dispatch func services req res send404)))
 
         (createServer listener).listen (port, (fun () -> printfn "Giraffe listening on http://localhost:%d" port))


### PR DESCRIPTION
## Background

`src/js/Server.fs` carried a comment claiming that storing `handler earlyReturn` as an `HttpFunc` mis-normalizes via Fable's auto-uncurrying (`curry2`) into "a function that returns a function", and therefore applied `handler earlyReturn ctx` **fully, per request**.

## The quirk does not reproduce

Tested on Fable 5.13: the emitted `curry2(handler)(earlyReturn)` is a correct one-argument function, and `func(ctx)` runs the pipeline. Verified against a live server — `/ping` → `pong`, `/json` → `{"Name":"Dag","Age":53}`, and the `/missing` → 404 fall-through.

## Change

Compose `func = handler earlyReturn` **once** in `run`/`toMiddleware` and pass it to `dispatch`, matching the Python (middleware ctor) and BEAM (`WebHost.Build`) backends. Rewrite the misleading comment to record the real behaviour.

## This is correctness/consistency, not a speedup — and that's intentional

A controlled A/B, `--noCache` with the generated call site **verified different at each step** (`handler(Core_earlyReturn, ctx)` per-request vs hoisted `func(ctx)`), 5 runs each:

| Variant | avg req/s |
|---|---|
| baseline (per-request) | ~68,550 |
| pre-composed once | ~68,060 |

Flat. Unlike BEAM (where composing per request cost ~5.4%), V8 inlines the trivial 2-handler composition and the `curry2` wrapper offsets the rest.

We're doing it anyway because it's the **correct shape**: the pipeline is composed once, all three backends now read the same, and the false comment is gone. It also positions JS to benefit for free from **future upstream `fable-library-js` task/CE improvements** — the per-request work is minimized on our side, so any reduction in Promise/CE overhead upstream lands without further changes here.

Behaviour unchanged: JS suite **53 passed, 2 skipped**.

## Note on JS perf generally
The real JS cost is structural — a Promise per `task{}` handler layer (dispatch → chooseHttpFunc → WriteBytesAsync → WriteAsync), all resolving synchronously since `res.end` is fire-and-forget. That's the upstream lever (fable-library-js task builder), not something reachable from this repo today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)