### PR TITLE
test: run BEAM suites in parallel again on Quill 0.5.1 / Nib 0.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ than literals for this reason.
 
 **BEAM was unblocked by Fable 5.13.0** (`fix(beam)` #4849 made reflection value access agree with
 record *and union* codegen — `PropertyInfo.GetValue` / `FSharpValue.MakeRecord` / `MakeUnion` no
-longer `{badkey,...}`). Remoting now runs on all three targets. Two BEAM-specific notes remain:
+longer `{badkey,...}`). Remoting now runs on all three targets. One BEAM-specific note remains:
 
 - Reflection reports the pristine F# field name, not the record-map key, so `getJsonMember`
   reproduces `sanitizeFieldName` via `toWireKey` (see above). The Fable team **declined** to change
@@ -118,11 +118,10 @@ longer `{badkey,...}`). Remoting now runs on all three targets. Two BEAM-specifi
   `toWireKey` is the **sanctioned** integration point — not a temporary shim to delete. `sanitizeFieldName`
   is stable; if it ever changes, the wire key is treated as contract. Background in
   `../Fable/BEAM-RECORD-FIELD-NAME-MANGLING-PROMPT.md`.
-- The BEAM test runner wraps the suites in `testSequenced` (`test/beam/Main.fs`): every remoting test
-  passes in isolation, but under Quill's default cross-suite concurrency on BEAM the body assertions
-  intermittently fail with a garbled diff. This is a Scriptorium/BEAM concurrency+rendering gap
-  (Scriptorium PRs #13/#15); revert to plain parallel `runTests` once they release — tracked in
-  issue #54.
+
+The BEAM `testSequenced` workaround is **gone** (issue #54 closed): Quill 0.5.1 (Unicode output on
+BEAM, Scriptorium #14) and Nib 0.4.1 (char-level diffs on BEAM, #15) fixed the garbled-diff failures,
+so `test/beam/Main.fs` runs the three suites with plain parallel `runTests` like the other targets.
 
 **Python tripwire on the next `fable-library-py` bump.** The Fable team is fixing Python reflection to
 report the *pristine* F# field name (like BEAM) while keeping the snake_case runtime slot
@@ -150,7 +149,7 @@ One behavioral suite in `test/shared/` (`HandlerTests.fs`, `RoutingTests.fs`) is
 per-target projects — `test/python`, `test/js`, `test/beam` — each supplying its own `TestContext.fs`
 (a `TestContext.create` factory building an isolated context without a real server) and a thin
 `Main.fs` entry point. `RemotingTests.fs` runs on all three targets as of Fable 5.13.0 (see the
-Remoting note below for the two BEAM-specific caveats: `toWireKey` and the `testSequenced` runner).
+Remoting note below for the remaining BEAM-specific caveat: `toWireKey`).
 
 Tests are written with [Scriptorium](https://github.com/fable-hub/Scriptorium) — Quill for the test
 DSL and runner, Nib for assertions — both of which compile to all three targets. `test/shared/Helpers.fs`

--- a/test/beam/Fable.Giraffe.Tests.Beam.fsproj
+++ b/test/beam/Fable.Giraffe.Tests.Beam.fsproj
@@ -16,8 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="5.2.0" />
-    <PackageReference Include="Scriptorium.Quill" Version="0.5.0" />
-    <PackageReference Include="Scriptorium.Nib" Version="0.4.0" />
+    <PackageReference Include="Scriptorium.Quill" Version="0.5.1" />
+    <PackageReference Include="Scriptorium.Nib" Version="0.4.1" />
     <PackageReference Include="Fable.Beam" Version="5.0.0-rc.33" />
     <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.24" />
   </ItemGroup>

--- a/test/beam/Main.fs
+++ b/test/beam/Main.fs
@@ -1,19 +1,11 @@
 module Fable.Giraffe.Tests.Main
 
 open type Scriptorium.Quill.Runner
-open type Scriptorium.Quill.Test
 
 // BEAM runner. Quill runs the suite synchronously here and calls `halt/1` with the exit code, so
 // `erl` returns non-zero when tests fail. Fable >= 5.8 namespaces generated BEAM modules and emits
 // a `main.erl` shim that dispatches to [<EntryPoint>], so the entry point keeps the runner findable
 // across Fable versions.
-//
-// The three suites are wrapped in `testSequenced` so they run one-suite-at-a-time rather than all
-// interleaved. Every remoting test passes on its own and the suite passes when run in isolation, but
-// under Quill's default cross-suite concurrency on BEAM the remoting body assertions intermittently
-// fail with a garbled diff (rendered as "1"). That is a Scriptorium/BEAM concurrency+rendering gap
-// tracked in Scriptorium PRs #13 (Quill 0.5.1 Unicode output) and #15 (Nib char-level diffs); once
-// those release, drop back to a plain parallel `runTests [ ...; RemotingTests.tests ]`. See #54.
 [<EntryPoint>]
 let main _ =
-    runTests [ testSequenced ("suite", [ HandlerTests.tests; RoutingTests.tests; RemotingTests.tests ]) ]
+    runTests [ HandlerTests.tests; RoutingTests.tests; RemotingTests.tests ]

--- a/test/js/Tests.fsproj
+++ b/test/js/Tests.fsproj
@@ -16,8 +16,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="5.2.0" />
-    <PackageReference Include="Scriptorium.Quill" Version="0.5.0" />
-    <PackageReference Include="Scriptorium.Nib" Version="0.4.0" />
+    <PackageReference Include="Scriptorium.Quill" Version="0.5.1" />
+    <PackageReference Include="Scriptorium.Nib" Version="0.4.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\js\Fable.Giraffe.Js.fsproj" />

--- a/test/python/Fable.Giraffe.Tests.Python.fsproj
+++ b/test/python/Fable.Giraffe.Tests.Python.fsproj
@@ -17,8 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Scriptorium.Quill" Version="0.5.0" />
-    <PackageReference Include="Scriptorium.Nib" Version="0.4.0" />
+    <PackageReference Include="Scriptorium.Quill" Version="0.5.1" />
+    <PackageReference Include="Scriptorium.Nib" Version="0.4.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Scriptorium released the two BEAM fixes tracked in #54:

- **Scriptorium.Quill 0.5.1** — correct Unicode output on the BEAM target ([Scriptorium #14](https://github.com/fable-hub/Scriptorium/pull/14))
- **Scriptorium.Nib 0.4.1** — render char-level diffs as characters on BEAM ([Scriptorium #15](https://github.com/fable-hub/Scriptorium/pull/15))

Those were the root cause of the garbled `"1"` diffs that made the remoting body assertions flake when the BEAM suites ran under Quill's default cross-suite concurrency.

## Changes

- `test/beam/Main.fs` — drop the `testSequenced` wrapper, the `open type Scriptorium.Quill.Test` it needed, and the workaround comment; back to plain parallel `runTests [ HandlerTests.tests; RoutingTests.tests; RemotingTests.tests ]`, matching the Python and JS runners.
- Bump `Scriptorium.Quill` 0.5.0 → 0.5.1 and `Scriptorium.Nib` 0.4.0 → 0.4.1 in all three test projects (`test/beam`, `test/js`, `test/python`).
- `CLAUDE.md` — BEAM now has one residual caveat (`toWireKey`) rather than two; note the `testSequenced` workaround is gone.

## Verification

All three targets green:

| Target | Result |
|---|---|
| BEAM (parallel) | 47 passed, 8 skipped — **5 consecutive runs**, all exit 0 |
| Python | 55 passed |
| JS | 53 passed, 2 skipped |

BEAM was run five times specifically because the original failure was intermittent; no flakes.

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)