### PR TITLE
fix(beam): make DI work across Cowboy's per-request process

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,18 +138,43 @@ All three backends wire `Fable.Logging` through the shared `src/Logging.fs`, opt
 `UseStructlog()` (Python), `UseConsoleLogging()` (JS), `UseBeamLogging()` (BEAM). Python and BEAM
 also emit a per-request access log gated on `LogLevel.Debug`; JS does not.
 
-**BEAM: objects cannot cross the Cowboy request boundary.** Cowboy spawns a fresh process per
-request, and Fable compiles a class with mutable fields to a *process-dictionary ref* — so any
-such object built in the builder process reads back as `undefined` inside the request process
-(`{badmap,undefined}`). This rules out passing an `ILogger` (or any Fable.Logging object) through
-Cowboy handler state. `GiraffeHandler` therefore receives `accessLogEnabled: bool` — an
-`IsEnabled LogLevel.Debug` evaluated once in `WebHost.Build`, which is sound because `Build`
-starts the listener and no `ConfigureLogging` can follow it — and emits via OTP's global `logger`,
-where `Fable.Logging.Beam`'s provider sends its output anyway. The cost is that a *custom*
-provider won't see the access log.
+### BEAM: what can cross the Cowboy request boundary
 
-The same constraint breaks `ctx.GetService` on BEAM (`ServiceCollection` is equally ref-backed);
-see FOLLOWUPS.md. Nothing in the suite covers it, since the tests bypass `GiraffeHandler`.
+Cowboy spawns a **fresh process per request**, and BEAM processes share nothing. The rule Fable
+applies is precise and worth internalising, because it decides what may be put into Cowboy
+handler state:
+
+> A class with **any** mutable field compiles to a **process-dictionary ref**; a class without one
+> compiles to a **plain map**.
+
+Compare the generated `service_collection_ctor` (has `member val Services with get, set` → calls
+`make_ref`) with `string_values_ctor` (no mutable fields → `#{field_strings => ...}`). A ref read
+from a *different* process yields `undefined`, and the next field access dies with
+`{badmap,undefined}` — a 500 with no obvious connection to the cause.
+
+Portable: records, unions, lists, tuples, funs, and **object expressions** (they compile to
+self-contained maps of funs — but only if they close over immutable data, not a ref).
+Not portable: any class with mutable fields, `Dictionary`, `ResizeArray`, and therefore every
+Fable.Logging logger and `ServiceCollection` itself.
+
+Two consequences, both handled in `src/beam`:
+
+- **Services.** `WebHost.Build` snapshots the collection to a `(string * ServiceDescriptor) list`
+  and `GiraffeHandler` rebuilds a `ServiceCollection` from it per request, in the process that
+  reads it. This keeps `RequestServices` typed as `ServiceCollection`, so shared `src/Helpers.fs`
+  and `src/HttpContextExtensions.fs` are untouched. It makes the *container* portable, not the
+  values: a registered service that is itself a mutable class is still a dead ref. On BEAM,
+  register immutable values.
+- **Logging.** `PortableLogger` (in `src/beam/WebHost.fs`) is an object expression closing over a
+  category name and a `LogLevel`, writing to OTP's global `logger`. `Build` registers it in place
+  of the ref-backed one `Logging.configure` added, and uses a second instance for the access log.
+  The effective level is recovered by probing `IsEnabled` at `Build` — the factory exposes no
+  getter, and `Build` is terminal, so no later `ConfigureLogging` can invalidate it. The cost is
+  that a *custom* provider does not receive these lines; upstream fixes that would remove
+  `PortableLogger` entirely are listed in FOLLOWUPS.md.
+
+The shared suite covers `AddSingleton` → `ctx.GetService`, but it bypasses `GiraffeHandler`, so it
+does **not** cover the process hop. Verify that by running `just app-beam`.
 
 ### Build System
 

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -22,29 +22,48 @@ visible until fixed.
 
 ## BEAM DI / logging
 
-- [ ] **BEAM `GetService` is broken across Cowboy's per-request process** — CONFIRMED, not
-      just unverified. Cowboy spawns a fresh process per request, and Fable compiles a class
-      with mutable fields to a process-dictionary ref (see the `fable_utils:field_get` /
-      `iface_get` comments in fable-library-beam: "process-dict ref … single-process"). The
-      `ServiceCollection` built in the builder process therefore reads back as `undefined`
-      inside the request process, and a handler calling `ctx.GetService<ILogger>()` dies with
-      `{badmap,undefined}` at `map_get(field_services, undefined)` → 500. Every Fable.Logging
-      logger is likewise a mutable class, so an `ILogger` cannot be passed through Cowboy
-      handler state either — this is why `GiraffeHandler` takes an `accessLogEnabled: bool`
-      and emits through OTP's global `logger` rather than carrying an `ILogger`.
-      Fixing DI needs a process-portable service representation (an immutable map, an ETS
-      table, or a named process), not just a test. `src/Helpers.fs`, `src/beam/Middleware.fs`.
-- [ ] **Cross-target DI test** — no test exercises `GetService` on any target, which is why
-      the above went unnoticed. Add one (register a service in each `TestContext.create`,
-      resolve it in a handler); note it will only reproduce the BEAM failure if the resolve
-      happens in a different process than the registration, as it does under Cowboy.
-      `test/shared/`, `test/*/TestContext.fs`.
-- [ ] **BEAM access log bypasses `ILoggerProvider`** — `GiraffeHandler` calls OTP `logger`
-      directly, so a custom provider registered via `ConfigureLogging` does not receive the
-      access log (its minimum level *is* honoured — the gate is an `IsEnabled` evaluated in
-      the builder process at `Build` time). Behaviourally identical for
-      `Fable.Logging.Beam`, which itself emits to OTP `logger`. Resolves once services are
-      process-portable.
+- [x] **BEAM `GetService` across Cowboy's per-request process** — FIXED. Cowboy spawns a fresh
+      process per request, and Fable compiles a class with *any* mutable field to a
+      process-dictionary ref (a class without one compiles to a plain map — compare the
+      generated `service_collection_ctor`, which calls `make_ref`, with `string_values_ctor`,
+      which does not). Both the `ServiceCollection` and the `Dictionary` behind it are refs, so
+      the collection built in the builder process read back as `undefined` and
+      `ctx.GetService<_>()` died with `{badmap,undefined}` → 500.
+      `WebHost.Build` now snapshots the services to a `(string * ServiceDescriptor) list` — an
+      ordinary term — and `GiraffeHandler` rebuilds a collection from it per request, in the
+      process that reads it. Shared `src/Helpers.fs` and `src/HttpContextExtensions.fs` are
+      untouched, so Python and JS are unaffected.
+- [ ] **BEAM services must be immutable values** — the snapshot above makes the *container*
+      portable, not the values in it. A registered service that is itself a class with mutable
+      fields is still a dead ref on the far side, failing with the same `{badmap,undefined}`.
+      This is inherent to BEAM's shared-nothing model — ETS or a named process would not help,
+      since neither can share a mutable *object*. Either document this as the contract
+      (records, funs and object expressions are fine) or detect ref-valued services at
+      registration and fail loudly at `Build` rather than per request. `src/beam/WebHost.fs`.
+- [ ] **BEAM access log bypasses `ILoggerProvider`** — the portable `ILogger` in
+      `src/beam/WebHost.fs` writes to OTP `logger` directly, so a custom provider registered
+      via `ConfigureLogging` does not receive the access log. Its minimum *level* is honoured
+      (`PortableLogger.effectiveLevel` probes `IsEnabled` at `Build`). Behaviourally identical
+      for `Fable.Logging.Beam`, which itself emits to OTP `logger`. Resolves if Fable.Logging
+      makes its loggers process-portable — see below.
+- [ ] **Upstream: make Fable.Logging loggers process-portable on BEAM** — `../Fable.Logging`.
+      Two separate asks:
+      (a) `Fable.Logging.Beam.Logger` has `member val MinimumLevel with get, set`, but
+      `LoggerProvider.CreateLogger` assigns it exactly once right after construction. Making it
+      a constructor parameter removes the only mutable field, so the class compiles to a
+      portable map. Small, no user-visible API change.
+      (b) The factory's own `Logger` mutates a `ResizeArray` of providers from
+      `ILoggerFactory.AddProvider`, which is what forces its ref. Fixing this means either
+      snapshotting providers at `CreateLogger` time (breaks late `AddProvider`) or documenting
+      factory loggers as process-local on BEAM.
+      With (a) and (b), `src/beam/WebHost.fs`'s hand-rolled `PortableLogger` can be deleted in
+      favour of `loggerFactory.CreateLogger`.
+- [ ] **DI test does not cover the process hop** — `test/shared/HandlerTests.fs` now covers
+      `AddSingleton` → `ctx.GetService` on all three backends, but it bypasses
+      `GiraffeHandler`, so registration and resolution share a process. Covering the real
+      Cowboy topology needs a test that drives `GiraffeHandler.init` itself (fake `Req` plus a
+      stub for `cowboy_req:reply`), or an integration test against a live listener. Until then
+      the cross-process path is verified by running `just app-beam`.
 
 ## Feature parity (Python-only today)
 

--- a/src/beam/Middleware.fs
+++ b/src/beam/Middleware.fs
@@ -3,10 +3,10 @@ namespace Fable.Giraffe
 open System.Threading.Tasks
 open Fable.Core
 open Fable.Beam.Cowboy.CowboyReq
+open Fable.Logging
 
 module CowboyReq = Fable.Beam.Cowboy.CowboyReq
 module CowboyHandler = Fable.Beam.Cowboy.CowboyHandler
-module Logger = Fable.Beam.Logger
 
 /// Cowboy handler module.
 /// Implements init/2 which:
@@ -28,46 +28,57 @@ module GiraffeHandler =
     /// The Cowboy handler init callback.
     /// Called for every incoming request.
     let init (req: Req) (state: obj) : obj =
-        // State is (func, services, accessLogEnabled) — the pipeline is composed once in
+        // State is (func, serviceSnapshot, logger) — the pipeline is composed once in
         // WebHost.Build, so init/2 (called by Cowboy for every request) does no per-request
-        // handler composition. `accessLogEnabled` is a bool rather than an ILogger on purpose:
+        // handler composition.
+        //
         // Cowboy runs every request in a fresh process, and Fable compiles a class with mutable
-        // fields to a process-dictionary ref, so a logger object built in the builder process
-        // reads back as `undefined` here. See the note in WebHost.Build.
-        let func, services, accessLogEnabled =
-            state :?> (HttpFunc * ServiceCollection * bool)
+        // fields to a process-dictionary ref — so neither a ServiceCollection nor a
+        // Fable.Logging logger built in the builder process can be read here. Hence a plain list
+        // of (key, descriptor) pairs plus an object-expression logger, both ordinary terms.
+        let func, serviceSnapshot, logger =
+            state :?> (HttpFunc * (string * ServiceDescriptor) list * ILogger)
 
-        // Create the HttpContext wrapping the Cowboy request and give it the services
-        // collection. NOTE: resolving off it via GetService does NOT currently work on BEAM —
-        // ServiceCollection is ref-backed for the same reason as the logger above, so
-        // `ctx.GetService<_>()` dies with {badmap,undefined} in this process. Tracked in
-        // FOLLOWUPS.md; the assignment stays so the fix is a change of representation only.
+        // Rebuild the service collection HERE, so its backing ref belongs to this process and
+        // ctx.GetService<_>() resolves. Cheap: a handful of entries, and only the dictionary is
+        // rebuilt — the registered instances are shared, not copied.
+        let services = ServiceCollection()
+
+        for key, descriptor in serviceSnapshot do
+            services.Services[key] <- descriptor
+
         let ctx = HttpContext(req)
         ctx.SetServices(services)
 
         // Only read the clock when the access log will actually be emitted; otherwise this is a
         // per-request BIF call on the hot path for nothing.
-        let start = if accessLogEnabled then monotonicTimeUs () else 0L
+        let logging = logger.IsEnabled LogLevel.Debug
+        let start = if logging then monotonicTimeUs () else 0L
 
         // Run the handler pipeline synchronously.
         // On BEAM, Task CE is a CPS alias for Async — identity cast.
         let _result = func ctx |> taskToAsync |> Async.RunSynchronously
 
-        if accessLogEnabled then
+        if logging then
             let elapsedMs = double (monotonicTimeUs () - start) / 1000.0
-            let statusCode = ctx.Response.StatusCode
-            let path = defaultArg ctx.Request.Path ""
-
-            // Same shape as the Python backend's access log, pre-rendered: OTP's logger is a
-            // global service reachable from any process, unlike the ILogger object graph.
-            let message =
-                $"Giraffe returned %d{statusCode} for %s{ctx.Request.Protocol} %s{ctx.Request.Method} "
-                + $"at %s{path} in %.3f{elapsedMs} ms"
 
             // Status -> level mirrors the Python backend: 2xx info, 3xx/4xx error, 5xx critical.
-            if statusCode < 300 then Logger.logger.info message
-            elif statusCode < 500 then Logger.logger.error message
-            else Logger.logger.critical message
+            let logLevel =
+                match ctx.Response.StatusCode with
+                | code when code < 300 -> LogLevel.Information
+                | code when code < 500 -> LogLevel.Error
+                | _ -> LogLevel.Critical
+
+            logger.Log(
+                logLevel,
+                "Giraffe returned {Status} for {HttpProtocol} {HttpMethod} at {Path} in {ElapsedMs}",
+                parameters =
+                    [| ctx.Response.StatusCode :> obj
+                       ctx.Request.Protocol
+                       ctx.Request.Method
+                       defaultArg ctx.Request.Path ""
+                       elapsedMs |]
+            )
 
         // Send the response via cowboy_req:reply/4.
         // Always use reply/4 — Cowboy handles empty iolist body ([]) fine.

--- a/src/beam/WebHost.fs
+++ b/src/beam/WebHost.fs
@@ -47,6 +47,59 @@ type IApplicationBuilder =
     /// shadow the Giraffe catch-all entirely. A prefix is therefore required.
     abstract UseStaticFiles: string * string -> unit
 
+/// A process-portable ILogger for BEAM.
+///
+/// Fable compiles a class with ANY mutable field to a process-dictionary ref, and a class
+/// without one to a plain map. Every Fable.Logging logger is in the first category
+/// (`Fable.Logging.Beam.Logger` has a settable `MinimumLevel`; the factory's own `Logger`
+/// mutates its provider list), so a logger built here is unreadable inside the fresh process
+/// Cowboy spawns per request — `erlang:get(Ref)` there returns `undefined`.
+///
+/// An object expression, by contrast, compiles to a self-contained map of funs, which is an
+/// ordinary term and crosses the boundary intact. This one closes over nothing but a string
+/// and a LogLevel, and writes to OTP's `logger` — a global service reachable from any process,
+/// and exactly where Fable.Logging.Beam's provider sends its own output.
+module PortableLogger =
+
+    /// `LogLevel.None` (6) sorts above `Critical` (5), so it doubles as the "disabled"
+    /// sentinel: every real level compares below it and nothing is emitted.
+    let create (categoryName: string) (minimumLevel: LogLevel) : ILogger =
+        { new ILogger with
+            member _.IsEnabled(logLevel: LogLevel) = logLevel >= minimumLevel
+
+            member _.Log(state: LogState) =
+                if state.Level >= minimumLevel then
+                    // translateFormat is Fable.Logging's own placeholder renderer, written with
+                    // plain string ops precisely so it runs on BEAM.
+                    let message, _ = Common.translateFormat categoryName state.Format state.Args
+
+                    match state.Level with
+                    | LogLevel.Trace
+                    | LogLevel.Debug -> Logger.logger.debug message
+                    | LogLevel.Information -> Logger.logger.info message
+                    | LogLevel.Warning -> Logger.logger.warning message
+                    | LogLevel.Error -> Logger.logger.error message
+                    | LogLevel.Critical -> Logger.logger.critical message
+                    | _ -> Logger.logger.info message
+
+            member _.BeginScope(_: obj) : IDisposable = failwith "Not implemented" }
+
+    /// Read the factory's effective threshold back out as a plain value.
+    ///
+    /// LoggerFactory exposes no minimum-level getter, but `IsEnabled` answers the same
+    /// question, so probe it from the bottom up and keep the lowest level that passes.
+    /// `IsEnabled` is also false for every level when no provider is registered, which is
+    /// what makes an unconfigured host produce a silent logger rather than noise.
+    let effectiveLevel (probe: ILogger) =
+        [ LogLevel.Trace
+          LogLevel.Debug
+          LogLevel.Information
+          LogLevel.Warning
+          LogLevel.Error
+          LogLevel.Critical ]
+        |> List.tryFind probe.IsEnabled
+        |> Option.defaultValue LogLevel.None
+
 type IWebHostBuilder =
     abstract Configure: Action<IApplicationBuilder> -> IWebHostBuilder
     abstract Build: int -> unit
@@ -56,6 +109,11 @@ type WebHostBuilder() =
     let services = ServiceCollection()
     let mutable handler: HttpHandler option = None
     let staticMounts = ResizeArray<string * string>()
+
+    // Whether ConfigureLogging ran, so Build registers an ILogger only when the other backends
+    // would have one. Without this an unconfigured BEAM host would hand out a silent no-op
+    // logger where Python/JS raise "Service not found" — a divergence for no benefit.
+    let mutable loggingConfigured = false
 
     interface IWebHostBuilder with
         member this.Configure(configureApp: Action<IApplicationBuilder>) =
@@ -92,24 +150,41 @@ type WebHostBuilder() =
                 // once in its middleware constructor).
                 let func: HttpFunc = h earlyReturn
 
-                // Access-log gate, resolved to a plain bool HERE rather than passed as an ILogger.
-                // Cowboy spawns a fresh process per request, and Fable compiles a class with
-                // mutable fields (which every Fable.Logging logger is) to a process-dictionary
-                // ref — so a logger built in this process reads back as `undefined` inside the
-                // request process. A bool is a plain term and crosses the boundary intact.
+                // Resolve the configured log level to a plain value once, here. Build is the
+                // right place because it is terminal — it starts the listener, so no further
+                // ConfigureLogging call can change the level afterwards.
+                let level = PortableLogger.effectiveLevel (loggerFactory.CreateLogger("Giraffe"))
+
+                // Replace the "Giraffe" logger that Logging.configure registered. That one comes
+                // from LoggerFactory and is therefore ref-backed, so resolving it via GetService
+                // inside a request process yields `undefined` and dies with {badmap,undefined}.
+                // The portable one behaves identically and survives the process hop.
+                if loggingConfigured then
+                    services.AddSingleton<ILogger>(PortableLogger.create "Giraffe" level)
+
+                // Snapshot the services as a plain list of (key, descriptor) pairs. Both the
+                // ServiceCollection and the Dictionary behind it are process-dict refs, so the
+                // collection itself cannot travel; a list of tuples of a single-case union is an
+                // ordinary term and can. GiraffeHandler rebuilds a collection from it per
+                // request, in the process that will actually read it.
                 //
-                // Evaluating IsEnabled once is safe because the factory's minimum level is fixed
-                // by the time Build runs: Build starts the listener, so no ConfigureLogging call
-                // can follow it. With no provider registered this is false and the access log
-                // costs nothing. GiraffeHandler then emits through OTP's global `logger`, which
-                // is exactly where Fable.Logging.Beam's provider sends its own output.
-                let accessLogEnabled =
-                    (loggerFactory.CreateLogger("GiraffeHandler")).IsEnabled LogLevel.Debug
+                // NOTE this makes the CONTAINER portable, not the values inside it. A service
+                // that is itself a class with mutable fields is still a dead ref on the far
+                // side — on BEAM, registered services must be immutable values (records, funs,
+                // object expressions). See FOLLOWUPS.md.
+                let serviceSnapshot =
+                    services.Services
+                    |> Seq.map (fun kv -> kv.Key, kv.Value)
+                    |> List.ofSeq
+
+                // The access log gets its own category, matching the Python backend's separate
+                // "GiraffeMiddleware" logger.
+                let accessLogger = PortableLogger.create "GiraffeHandler" level
 
                 // Catch-all: every remaining path → middleware module with the composed pipeline,
-                // the services collection and the access-log gate as state.
+                // the portable service snapshot and the access logger as state.
                 let catchAllRoute =
-                    CowboyRouter.route "/[...]" CowboyFFI.middlewareAtom (func, services, accessLogEnabled)
+                    CowboyRouter.route "/[...]" CowboyFFI.middlewareAtom (func, serviceSnapshot, accessLogger)
 
                 let hostRule =
                     CowboyRouter.hostRule CowboyRouter.wildcard (staticRoutes @ [ catchAllRoute ])
@@ -134,6 +209,7 @@ type WebHostBuilder() =
 
     member this.ConfigureLogging(configureLogging: Action<ILoggingBuilder>) =
         Logging.configure loggerFactory services configureLogging
+        loggingConfigured <- true
         this
 
     /// Log via Fable.Logging's BEAM (logger/OTP) provider — the BEAM counterpart of the

--- a/test/beam/TestContext.fs
+++ b/test/beam/TestContext.fs
@@ -20,10 +20,11 @@ module private BeamFakes =
 type TestContext =
 
     static member create
-        (?method: string, ?path: string, ?status: int, ?headers: HeaderDictionary, ?body: string)
+        (?method: string, ?path: string, ?status: int, ?headers: HeaderDictionary, ?body: string, ?services: ServiceCollection)
         : HttpContext * (unit -> byte[]) =
         let _method = defaultArg method "GET"
         let _path = defaultArg path "/"
         let _body = defaultArg body ""
         let ctx = HttpContext(BeamFakes.makeReq _method _path _body)
+        ctx.SetServices(defaultArg services (ServiceCollection()))
         ctx, (fun () -> ctx.Response.Body)

--- a/test/js/TestContext.fs
+++ b/test/js/TestContext.fs
@@ -24,7 +24,7 @@ module private JsFakes =
 type TestContext =
 
     static member create
-        (?method: string, ?path: string, ?status: int, ?headers: HeaderDictionary, ?body: string)
+        (?method: string, ?path: string, ?status: int, ?headers: HeaderDictionary, ?body: string, ?services: ServiceCollection)
         : HttpContext * (unit -> byte[]) =
         let _method = defaultArg method "GET"
         let _path = defaultArg path "/"
@@ -41,5 +41,5 @@ type TestContext =
 
         let req = JsFakes.makeReq _method _body _path headersObj
         let res = JsFakes.makeRes ()
-        let ctx = HttpContext(req, res, ServiceCollection())
+        let ctx = HttpContext(req, res, defaultArg services (ServiceCollection()))
         ctx, (fun () -> JsFakes.capturedBody res)

--- a/test/python/TestContext.fs
+++ b/test/python/TestContext.fs
@@ -13,11 +13,11 @@ open Fable.Giraffe
 type TestContext =
 
     static member create
-        (?method: string, ?path: string, ?status: int, ?headers: HeaderDictionary, ?body: string)
+        (?method: string, ?path: string, ?status: int, ?headers: HeaderDictionary, ?body: string, ?services: ServiceCollection)
         : HttpContext * (unit -> byte[]) =
         let _method = defaultArg method "GET"
         let _path = defaultArg path "/"
-        let services = ServiceCollection()
+        let services = defaultArg services (ServiceCollection())
 
         let _headers =
             defaultArg headers (HeaderDictionary())

--- a/test/shared/HandlerTests.fs
+++ b/test/shared/HandlerTests.fs
@@ -14,6 +14,11 @@ open Fable.Giraffe
 
 type Dummy = { foo: string; bar: string; age: int }
 
+/// Resolved out of the service collection by the DI test below. A record so it is an
+/// immutable value on every backend — on BEAM a service that is a class with mutable fields
+/// is a process-dictionary ref and cannot be shared across processes at all.
+type Greeter = { Greeting: string }
+
 // ---------------------------------
 // Tests
 // ---------------------------------
@@ -350,6 +355,40 @@ let tests =
                           | None -> failwith "It was expected that the request would be redirected"
                           | Some ctx -> assertThat ctx.Response.StatusCode (isEqualTo 301)
                       // TODO: ctx.Response.Headers
+                      }
+                  )
+          )
+
+          // Covers the DI surface itself (AddSingleton -> ctx.GetService) on all three backends.
+          // It does NOT cover BEAM's real failure mode: under Cowboy the collection is built in
+          // the builder process and read in a per-request one, and a ServiceCollection is a
+          // process-dictionary ref that cannot cross that boundary. GiraffeHandler carries a
+          // portable snapshot and rebuilds the collection per request to fix that, but this test
+          // bypasses GiraffeHandler entirely, so registration and resolution share a process
+          // here. The cross-process path is exercised by running the example app.
+          testAsync (
+              "ctx.GetService resolves a registered singleton",
+              fun _ ->
+                  toAsync (
+                      task {
+                          let services = ServiceCollection()
+                          services.AddSingleton<Greeter> { Greeting = "Hello from DI" }
+
+                          let testCtx, readBody = TestContext.create (path = "/di", services = services)
+
+                          let app =
+                              choose
+                                  [ route "/di"
+                                    >=> fun next ctx -> text (ctx.GetService<Greeter>()).Greeting next ctx
+                                    setStatusCode 404 >=> text "Not found" ]
+
+                          let expected = "Hello from DI" |> Encoding.UTF8.GetBytes
+
+                          let! result = app next testCtx
+
+                          match result with
+                          | None -> failwith $"Result was expected to be {expected}"
+                          | Some _ -> assertThat (readBody ()) (isEqualTo expected)
                       }
                   )
           ) ]


### PR DESCRIPTION
Stacked on #70 — review that first; the diff here is against `feat/beam-logging`.

## The bug

`ctx.GetService<_>()` on BEAM died with `{badmap,undefined}` → 500:

```
{erlang,map_get,[field_services,undefined],...},
{fable_utils,field_get,2,...},
{src_helpers,service_collection_get_service_24524716,2,...}
```

## Root cause

Cowboy spawns a fresh process per request, and BEAM processes share nothing. The rule Fable applies is precise:

> A class with **any** mutable field compiles to a **process-dictionary ref**; a class without one compiles to a **plain map**.

Confirmed against generated Erlang — `ServiceCollection` (`member val Services with get, set`) calls `make_ref()`, while `StringValues` (no mutable fields) is `State0 = #{field_strings => Strings}`. Both the `ServiceCollection` *and* the `Dictionary` behind it are refs, so the collection built in the builder process reads back as `undefined` in the request process.

## Fix

**1. Snapshot the container, rebuild per request.** `WebHost.Build` flattens the services to a `(string * ServiceDescriptor) list` — string keys and a single-case union, both ordinary terms — and `GiraffeHandler` rebuilds a `ServiceCollection` from it in the process that will actually read it.

Shared `src/Helpers.fs` and `src/HttpContextExtensions.fs` are **untouched**, so Python and JS are unaffected and `RequestServices` stays typed `ServiceCollection`. Cost is one dictionary rebuild over a handful of entries; the registered instances are shared, not copied.

**2. A portable `ILogger`.** Step 1 fixes the container but not ref-valued services — and the `"Giraffe"` logger `Logging.configure` registers is exactly such a value. `Build` now replaces it with `PortableLogger`: an **object expression**, which compiles to a self-contained map of funs and does cross the boundary, closing over only a category name and a `LogLevel` and writing to OTP's global `logger`.

The effective level is recovered by probing `IsEnabled` at `Build` — `LoggerFactory` exposes no getter, and `Build` is terminal so no later `ConfigureLogging` can invalidate it. Registration is gated on `ConfigureLogging` having run, so an unconfigured host raises `Service not found` like Python/JS rather than silently no-op logging.

This **supersedes the `accessLogEnabled: bool`** from #70 — the access log now goes through a second `PortableLogger`, so `GiraffeHandler` matches the Python middleware structurally instead of carrying a special case.

## Verification

Automated: cross-target DI test (`AddSingleton` → `ctx.GetService`) added via a new optional `services` seam on each `TestContext.create`. Python 56, JS 54 + 2 skipped, BEAM 48 + 8 skipped.

**This test does not cover the bug.** It bypasses `GiraffeHandler`, so registration and resolution share a process. It's regression cover for the DI surface only.

The cross-process path was verified by running the app with a throwaway `/probe` route resolving `ILogger` (since reverted):

```
GET /probe  -> probed [200]
Giraffe - probe resolved ILogger in the request process
GiraffeHandler - Giraffe returned 200 for http GET at /probe in 16.345
```

That route returned 500 with `{badmap,undefined}` before this change. With logging unconfigured it instead raises `Service { Fullname = "Fable.Logging.ILogger" ... } not found` — matching Python/JS — and normal routes are unaffected.

## Residual limits (documented, not fixed)

- **A service that is itself a mutable class is still a dead ref** on the far side. Inherent to BEAM's shared-nothing model — ETS or a named process wouldn't help either, since neither can share a mutable *object*. On BEAM, register immutable values (records, funs, object expressions).
- **The access log bypasses `ILoggerProvider`** — a custom provider won't see it, though its minimum level is honoured. Behaviourally identical for `Fable.Logging.Beam`, which itself emits to OTP `logger`.
- **Upstream `Fable.Logging` fixes** that would let `PortableLogger` be deleted entirely are written up in FOLLOWUPS.md: (a) `Fable.Logging.Beam.Logger.MinimumLevel` is settable but assigned exactly once right after construction — making it a constructor parameter removes the only mutable field, ~2 lines, no user-visible API change; (b) the factory's own `Logger` mutates a provider `ResizeArray` from `AddProvider`, which is the harder design question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)