### PR TITLE
chore: upgrade Fable.Logging to 1.0.0 and drop PortableLogger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,13 +165,17 @@ Two consequences, both handled in `src/beam`:
   and `src/HttpContextExtensions.fs` are untouched. It makes the *container* portable, not the
   values: a registered service that is itself a mutable class is still a dead ref. On BEAM,
   register immutable values.
-- **Logging.** `PortableLogger` (in `src/beam/WebHost.fs`) is an object expression closing over a
-  category name and a `LogLevel`, writing to OTP's global `logger`. `Build` registers it in place
-  of the ref-backed one `Logging.configure` added, and uses a second instance for the access log.
-  The effective level is recovered by probing `IsEnabled` at `Build` — the factory exposes no
-  getter, and `Build` is terminal, so no later `ConfigureLogging` can invalidate it. The cost is
-  that a *custom* provider does not receive these lines; upstream fixes that would remove
-  `PortableLogger` entirely are listed in FOLLOWUPS.md.
+- **Logging.** Nothing special is needed as of **Fable.Logging 1.0.0**, which made its loggers
+  process-portable (they hold no mutable state and snapshot the factory's providers at creation).
+  `Build` just calls `loggerFactory.CreateLogger` for the access log, and the `"Giraffe"` logger
+  `Logging.configure` registers travels in the snapshot like any other service. Fable.Giraffe
+  briefly carried its own object-expression `PortableLogger` for this; it is gone, and with it the
+  limitation that a custom `ILoggerProvider` never saw the access log.
+
+  One ordering constraint follows from that upstream change: a logger snapshots providers and
+  level when created, and `AddProvider` no longer reaches back into loggers already handed out. So
+  loggers must be created *after* configuration — `Logging.configure` re-registers on every
+  `ConfigureLogging` call, and `Build` creates the access logger last. See `src/Logging.fs`.
 
 The shared suite covers `AddSingleton` → `ctx.GetService`, but it bypasses `GiraffeHandler`, so it
 does **not** cover the process hop. Verify that by running `just app-beam`.

--- a/FOLLOWUPS.md
+++ b/FOLLOWUPS.md
@@ -40,24 +40,19 @@ visible until fixed.
       since neither can share a mutable *object*. Either document this as the contract
       (records, funs and object expressions are fine) or detect ref-valued services at
       registration and fail loudly at `Build` rather than per request. `src/beam/WebHost.fs`.
-- [ ] **BEAM access log bypasses `ILoggerProvider`** — the portable `ILogger` in
-      `src/beam/WebHost.fs` writes to OTP `logger` directly, so a custom provider registered
-      via `ConfigureLogging` does not receive the access log. Its minimum *level* is honoured
-      (`PortableLogger.effectiveLevel` probes `IsEnabled` at `Build`). Behaviourally identical
-      for `Fable.Logging.Beam`, which itself emits to OTP `logger`. Resolves if Fable.Logging
-      makes its loggers process-portable — see below.
-- [ ] **Upstream: make Fable.Logging loggers process-portable on BEAM** — `../Fable.Logging`.
-      Two separate asks:
-      (a) `Fable.Logging.Beam.Logger` has `member val MinimumLevel with get, set`, but
-      `LoggerProvider.CreateLogger` assigns it exactly once right after construction. Making it
-      a constructor parameter removes the only mutable field, so the class compiles to a
-      portable map. Small, no user-visible API change.
-      (b) The factory's own `Logger` mutates a `ResizeArray` of providers from
-      `ILoggerFactory.AddProvider`, which is what forces its ref. Fixing this means either
-      snapshotting providers at `CreateLogger` time (breaks late `AddProvider`) or documenting
-      factory loggers as process-local on BEAM.
-      With (a) and (b), `src/beam/WebHost.fs`'s hand-rolled `PortableLogger` can be deleted in
-      favour of `loggerFactory.CreateLogger`.
+- [x] **BEAM access log bypassed `ILoggerProvider`** — FIXED by Fable.Logging 1.0.0. The
+      hand-rolled `PortableLogger` wrote to OTP `logger` directly, so a custom provider never
+      saw the access log. `Build` now uses `loggerFactory.CreateLogger`, so provider dispatch
+      works normally.
+- [x] **Upstream: make Fable.Logging loggers process-portable on BEAM** — SHIPPED in
+      Fable.Logging 1.0.0 (`feat!: make loggers process-portable on the BEAM`, #40). Both asks
+      landed — `Fable.Logging.Beam.Logger` takes its level as a constructor parameter, and the
+      factory's `Logger` snapshots providers into an immutable list — plus a
+      `LoggerFactory.MinimumLevel` getter. `PortableLogger` and its `IsEnabled`-probing level
+      recovery are deleted. Written up in `../Fable.Logging/BEAM-PROCESS-PORTABLE-LOGGERS-PROMPT.md`.
+      **Breaking change to respect:** `AddProvider` no longer affects loggers already created,
+      so loggers must be created after configuration. `src/Logging.fs` documents where this
+      binds.
 - [ ] **DI test does not cover the process hop** — `test/shared/HandlerTests.fs` now covers
       `AddSingleton` → `ctx.GetService` on all three backends, but it bypasses
       `GiraffeHandler`, so registration and resolution share a process. Covering the real

--- a/src/Logging.fs
+++ b/src/Logging.fs
@@ -15,6 +15,15 @@ open Fable.Logging
 // context, so handlers there resolve the "Giraffe" logger via GetService like everywhere else.
 module Logging =
 
+    /// Apply the caller's logging configuration, then (re)register the "Giraffe" logger.
+    ///
+    /// The order matters as of Fable.Logging 1.0.0: a logger snapshots the factory's providers
+    /// and minimum level when it is created, and `AddProvider` no longer reaches back into
+    /// loggers already handed out (that mutable state is what made them process-local on BEAM).
+    /// Creating the logger AFTER the callback is therefore required, and re-registering on every
+    /// ConfigureLogging call is what keeps the singleton current when a host chains several —
+    /// e.g. `.ConfigureLogging(SetMinimumLevel Debug).UseStructlog()`, where the provider only
+    /// arrives on the second call. Last call wins, and it has seen all configuration so far.
     let configure (loggerFactory: LoggerFactory) (services: ServiceCollection) (configureLogging: Action<ILoggingBuilder>) =
         let loggingBuilder = loggerFactory :> ILoggingBuilder
         configureLogging.Invoke(loggingBuilder)

--- a/src/beam/Fable.Giraffe.Beam.fsproj
+++ b/src/beam/Fable.Giraffe.Beam.fsproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Fable.Core" Version="5.2.0" />
     <PackageReference Include="Fable.Beam" Version="5.0.0-rc.34" />
     <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.24" />
-    <PackageReference Include="Fable.Logging" Version="0.12.8" />
-    <PackageReference Include="Fable.Logging.Beam" Version="0.12.8" />
+    <PackageReference Include="Fable.Logging" Version="1.0.0" />
+    <PackageReference Include="Fable.Logging.Beam" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/src/beam/WebHost.fs
+++ b/src/beam/WebHost.fs
@@ -47,59 +47,6 @@ type IApplicationBuilder =
     /// shadow the Giraffe catch-all entirely. A prefix is therefore required.
     abstract UseStaticFiles: string * string -> unit
 
-/// A process-portable ILogger for BEAM.
-///
-/// Fable compiles a class with ANY mutable field to a process-dictionary ref, and a class
-/// without one to a plain map. Every Fable.Logging logger is in the first category
-/// (`Fable.Logging.Beam.Logger` has a settable `MinimumLevel`; the factory's own `Logger`
-/// mutates its provider list), so a logger built here is unreadable inside the fresh process
-/// Cowboy spawns per request — `erlang:get(Ref)` there returns `undefined`.
-///
-/// An object expression, by contrast, compiles to a self-contained map of funs, which is an
-/// ordinary term and crosses the boundary intact. This one closes over nothing but a string
-/// and a LogLevel, and writes to OTP's `logger` — a global service reachable from any process,
-/// and exactly where Fable.Logging.Beam's provider sends its own output.
-module PortableLogger =
-
-    /// `LogLevel.None` (6) sorts above `Critical` (5), so it doubles as the "disabled"
-    /// sentinel: every real level compares below it and nothing is emitted.
-    let create (categoryName: string) (minimumLevel: LogLevel) : ILogger =
-        { new ILogger with
-            member _.IsEnabled(logLevel: LogLevel) = logLevel >= minimumLevel
-
-            member _.Log(state: LogState) =
-                if state.Level >= minimumLevel then
-                    // translateFormat is Fable.Logging's own placeholder renderer, written with
-                    // plain string ops precisely so it runs on BEAM.
-                    let message, _ = Common.translateFormat categoryName state.Format state.Args
-
-                    match state.Level with
-                    | LogLevel.Trace
-                    | LogLevel.Debug -> Logger.logger.debug message
-                    | LogLevel.Information -> Logger.logger.info message
-                    | LogLevel.Warning -> Logger.logger.warning message
-                    | LogLevel.Error -> Logger.logger.error message
-                    | LogLevel.Critical -> Logger.logger.critical message
-                    | _ -> Logger.logger.info message
-
-            member _.BeginScope(_: obj) : IDisposable = failwith "Not implemented" }
-
-    /// Read the factory's effective threshold back out as a plain value.
-    ///
-    /// LoggerFactory exposes no minimum-level getter, but `IsEnabled` answers the same
-    /// question, so probe it from the bottom up and keep the lowest level that passes.
-    /// `IsEnabled` is also false for every level when no provider is registered, which is
-    /// what makes an unconfigured host produce a silent logger rather than noise.
-    let effectiveLevel (probe: ILogger) =
-        [ LogLevel.Trace
-          LogLevel.Debug
-          LogLevel.Information
-          LogLevel.Warning
-          LogLevel.Error
-          LogLevel.Critical ]
-        |> List.tryFind probe.IsEnabled
-        |> Option.defaultValue LogLevel.None
-
 type IWebHostBuilder =
     abstract Configure: Action<IApplicationBuilder> -> IWebHostBuilder
     abstract Build: int -> unit
@@ -109,11 +56,6 @@ type WebHostBuilder() =
     let services = ServiceCollection()
     let mutable handler: HttpHandler option = None
     let staticMounts = ResizeArray<string * string>()
-
-    // Whether ConfigureLogging ran, so Build registers an ILogger only when the other backends
-    // would have one. Without this an unconfigured BEAM host would hand out a silent no-op
-    // logger where Python/JS raise "Service not found" — a divergence for no benefit.
-    let mutable loggingConfigured = false
 
     interface IWebHostBuilder with
         member this.Configure(configureApp: Action<IApplicationBuilder>) =
@@ -150,18 +92,6 @@ type WebHostBuilder() =
                 // once in its middleware constructor).
                 let func: HttpFunc = h earlyReturn
 
-                // Resolve the configured log level to a plain value once, here. Build is the
-                // right place because it is terminal — it starts the listener, so no further
-                // ConfigureLogging call can change the level afterwards.
-                let level = PortableLogger.effectiveLevel (loggerFactory.CreateLogger("Giraffe"))
-
-                // Replace the "Giraffe" logger that Logging.configure registered. That one comes
-                // from LoggerFactory and is therefore ref-backed, so resolving it via GetService
-                // inside a request process yields `undefined` and dies with {badmap,undefined}.
-                // The portable one behaves identically and survives the process hop.
-                if loggingConfigured then
-                    services.AddSingleton<ILogger>(PortableLogger.create "Giraffe" level)
-
                 // Snapshot the services as a plain list of (key, descriptor) pairs. Both the
                 // ServiceCollection and the Dictionary behind it are process-dict refs, so the
                 // collection itself cannot travel; a list of tuples of a single-case union is an
@@ -171,15 +101,18 @@ type WebHostBuilder() =
                 // NOTE this makes the CONTAINER portable, not the values inside it. A service
                 // that is itself a class with mutable fields is still a dead ref on the far
                 // side — on BEAM, registered services must be immutable values (records, funs,
-                // object expressions). See FOLLOWUPS.md.
+                // object expressions). Fable.Logging's own loggers satisfy this as of 1.0.0.
+                // See FOLLOWUPS.md.
                 let serviceSnapshot =
                     services.Services
                     |> Seq.map (fun kv -> kv.Key, kv.Value)
                     |> List.ofSeq
 
                 // The access log gets its own category, matching the Python backend's separate
-                // "GiraffeMiddleware" logger.
-                let accessLogger = PortableLogger.create "GiraffeHandler" level
+                // "GiraffeMiddleware" logger. Created here, after every ConfigureLogging call:
+                // Fable.Logging 1.0.0 loggers snapshot the factory's providers and level at
+                // creation, so one built earlier would miss providers registered later.
+                let accessLogger = loggerFactory.CreateLogger("GiraffeHandler")
 
                 // Catch-all: every remaining path → middleware module with the composed pipeline,
                 // the portable service snapshot and the access logger as state.
@@ -209,7 +142,6 @@ type WebHostBuilder() =
 
     member this.ConfigureLogging(configureLogging: Action<ILoggingBuilder>) =
         Logging.configure loggerFactory services configureLogging
-        loggingConfigured <- true
         this
 
     /// Log via Fable.Logging's BEAM (logger/OTP) provider — the BEAM counterpart of the

--- a/src/js/Fable.Giraffe.Js.fsproj
+++ b/src/js/Fable.Giraffe.Js.fsproj
@@ -36,7 +36,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="5.2.0" />
-    <PackageReference Include="Fable.Logging" Version="0.12.8" />
+    <PackageReference Include="Fable.Logging" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />

--- a/src/python/Fable.Giraffe.Python.fsproj
+++ b/src/python/Fable.Giraffe.Python.fsproj
@@ -36,8 +36,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Fable.Core" Version="5.2.0" />
-    <PackageReference Include="Fable.Logging" Version="0.12.8" />
-    <PackageReference Include="Fable.Logging.Structlog" Version="0.12.8" />
+    <PackageReference Include="Fable.Logging" Version="1.0.0" />
+    <PackageReference Include="Fable.Logging.Structlog" Version="1.0.0" />
     <PackageReference Include="Fable.Python" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Stacked on #71 (which is stacked on #70) — the diff here is against `feat/beam-di-services`.

Net **−104 / +44**: this deletes more than it adds.

## What upstream shipped

[Fable.Logging 1.0.0](https://www.nuget.org/packages/Fable.Logging/1.0.0) — `feat!: make loggers process-portable on the BEAM` (Fable.Logging#40) — takes both asks written up in `../Fable.Logging/BEAM-PROCESS-PORTABLE-LOGGERS-PROMPT.md`:

- `Fable.Logging.Beam.Logger` takes its minimum level as a **constructor parameter** instead of a settable member.
- The factory's aggregating `Logger` **snapshots providers into an immutable list** rather than holding a `ResizeArray`.
- Bonus: a `LoggerFactory.MinimumLevel` getter.

Neither logger holds mutable state now, so both compile to plain maps instead of `make_ref()` keys into the process dictionary — and both survive the hop into the fresh process Cowboy spawns per request.

## What that lets us delete

`PortableLogger` — the hand-rolled object-expression `ILogger` from #71 — is gone, along with its `IsEnabled`-probing level recovery (obsolete now that `MinimumLevel` has a getter). `Build` just calls `loggerFactory.CreateLogger` for the access log, and the `"Giraffe"` logger `Logging.configure` registers travels in the service snapshot like any other value.

**This also fixes a limitation `PortableLogger` carried:** it wrote to OTP `logger` directly, so a custom `ILoggerProvider` never received the access log. Provider dispatch now works normally.

The `loggingConfigured` flag is gone too. It existed so `Build` only overrode the registration when the other backends would have had a logger; with no override at all, `Logging.configure` gives that parity for free.

The **`ServiceCollection` snapshot from #71 stays** — that's Fable.Giraffe's own ref-backed type, unaffected by the upstream fix.

## The breaking change, and why we're safe

> `AddProvider` no longer affects loggers already created, only ones created afterwards.

`Logging.configure` creates its logger **after** invoking the caller's callback, and re-registers on **every** `ConfigureLogging` call. So a chained host like `.ConfigureLogging(SetMinimumLevel Debug).UseStructlog()` — where the provider only arrives on the second call — still ends up with a logger that has seen all configuration. Last call wins.

That ordering was incidental before and is load-bearing now, so it's documented at the call site in `src/Logging.fs`. `Build` likewise creates the access logger last.

## Verification

Tests: Python 56, JS 54 + 2 skipped, BEAM 48 + 8 skipped — unchanged.

As in #71, the suite bypasses `GiraffeHandler`, so the cross-process path was verified by running the app with a throwaway `/probe` route (since reverted):

```
GET /probe  -> probed [200]
Giraffe - probe resolved ILogger in the request process
GiraffeHandler - Giraffe returned 200 for http GET at /probe in 18.038
```

Identical to #71's result, but now through `loggerFactory.CreateLogger` rather than a hand-rolled logger. With logging unconfigured: `Service { Fullname = "Fable.Logging.ILogger" ... } not found` (matching Python/JS), no access log, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)