### PR TITLE
chore: force next release to 5.3.0 instead of 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+force_version: 5.3.0
 last_commit_released: 4020946b153b18572b4aa37e699ee35c0bdd41d0
 name: Fable.Giraffe
 ---

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ once in F# and run it on three runtimes:
 | Erlang/BEAM | OTP | Cowboy |
 
 Fable.Giraffe's major version tracks the Fable compiler it targets: the 5.x
-line is built with and requires Fable 5.
+line is built with and requires Fable 5. The major is therefore *not* a SemVer
+signal — a breaking change can land in a minor release, and will be listed under
+**Breaking changes** in [CHANGELOG.md](CHANGELOG.md). Read it before upgrading.
 
 Beyond the Giraffe handler API, it ships an opt-in
 [endpoint layer](#openapi) that generates an **OpenAPI 3.1** document and serves


### PR DESCRIPTION
Closes the version question raised by #73.

ShipIt proposed **6.0.0** because #74 carries a breaking-change marker. But Fable.Giraffe's major version tracks the **Fable compiler**, not SemVer — the 5.x line means "built with and requires Fable 5", so a Fable.Giraffe 6.x would wrongly imply Fable 6.

## The change

`force_version: 5.3.0` in the CHANGELOG front matter, the same mechanism Fable.TypedJson used in dbrattli/Fable.TypedJson#46. ShipIt consumes it and strips it from the front matter on release, so it is a one-shot override and does not need cleaning up afterwards.

5.3.0 rather than 5.2.1: #74 adds features (the endpoint layer, OpenAPI generation, `validateJson`), so a minor bump is right for everything except the part the major would normally signal.

**The commit markers are deliberately left alone.** #74 still appears under "🏗️ Breaking changes" in the generated changelog — only the version number it lands in changes. Rewriting history to hide the breakage would be the wrong fix.

## One consequence, now documented

Pinning the major to Fable's means the version number stops carrying SemVer information: a breaking change can land in a minor release, and 5.3.0 is exactly such a release — the JSON wire format changes from PascalCase/snake_case to camelCase on every backend.

That is a reasonable policy, but it is only safe if users know about it, so the README now says so directly and points at the changelog:

> The major is therefore *not* a SemVer signal — a breaking change can land in a minor release, and will be listed under **Breaking changes** in CHANGELOG.md. Read it before upgrading.

Worth deciding once whether that is the intended long-term policy. The alternative — letting the major float on SemVer and stating the required Fable version in the package metadata instead — keeps SemVer meaningful, at the cost of the version no longer telling you which Fable it targets. This PR assumes the current policy stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)