### PR TITLE
fix(beam): make embedding in a host application work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,14 @@ obj/
 .vscode/
 Fable.Giraffe.sln.DotSettings.user
 
-# BEAM build output lives under build/ (already gitignored)
+# BEAM build output. The Justfile targets build/ (ignored above), but Fable and rebar3 land
+# elsewhere the moment anything else drives them — a consumer compiling this project by
+# ProjectReference, a rebar3 run at the repo root, or an outDir that follows the apps/ convention.
+# Generated .erl and its rebar3 output should never be a diff.
+apps/
+_build/
+rebar.lock
+fable_modules/
 
 .fake
 .claude/worktrees/

--- a/src/beam/Fable.Giraffe.Beam.fsproj
+++ b/src/beam/Fable.Giraffe.Beam.fsproj
@@ -28,8 +28,11 @@
     <Compile Include="../HttpHandler.fs" Link="HttpHandler.fs" />
     <Compile Include="../HttpStatusCodeHandlers.fs" Link="HttpStatusCodeHandlers.fs" />
     <Compile Include="../Logging.fs" Link="Logging.fs" />
-    <Compile Include="WebHost.fs" />
+    <!-- Middleware before WebHost: WebHost routes Cowboy to GiraffeHandler.moduleAtom(), which
+         has to be defined in the module it names. Middleware itself depends only on HttpContext,
+         Core/Helpers, PlatformHelpers and Logging, all of which precede it. -->
     <Compile Include="Middleware.fs" />
+    <Compile Include="WebHost.fs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="\" />

--- a/src/beam/Middleware.fs
+++ b/src/beam/Middleware.fs
@@ -2,6 +2,7 @@ namespace Fable.Giraffe
 
 open System.Threading.Tasks
 open Fable.Core
+open Fable.Beam
 open Fable.Beam.Cowboy.CowboyReq
 open Fable.Logging
 
@@ -18,6 +19,25 @@ module GiraffeHandler =
     /// On BEAM, Task CE is a CPS alias for Async. Identity cast.
     [<Emit("$0")>]
     let private taskToAsync (t: Task<'a>) : Async<'a> = nativeOnly
+
+    [<Emit("?MODULE")>]
+    let private selfModule () : Atom = nativeOnly
+
+    /// This module's own Erlang atom, for the caller that routes Cowboy here.
+    ///
+    /// Fable derives generated BEAM module names from the source path, and that path depends on
+    /// how the project is consumed: compiled standalone this file becomes
+    /// `fable_giraffe_beam_middleware`, referenced from a sibling app it becomes
+    /// `src_beam_middleware`, and referenced from another repository it becomes
+    /// `fable_giraffe_src_beam_middleware`. A hand-written atom cannot track that, and a wrong
+    /// one fails at the first request with `undef` on `init/2` rather than at startup.
+    ///
+    /// `?MODULE` is expanded by the Erlang preprocessor in the file the text appears in, and
+    /// `[<Emit>]` is inlined at the *call site* — so this has to live here and be reached
+    /// through an ordinary cross-module call. Do not mark it `inline`, and do not lift the
+    /// `[<Emit>]` into a value that WebHost references: either would expand `?MODULE` in the
+    /// caller and yield the caller's name.
+    let moduleAtom () : Atom = selfModule ()
 
     /// Monotonic clock for the access log. Fable.Beam's `Erlang.monotonicTimeMs` is
     /// millisecond-resolution, which rounds most handler runs to 0 — read microseconds so the

--- a/src/beam/WebHost.fs
+++ b/src/beam/WebHost.fs
@@ -8,19 +8,17 @@ open Fable.Logging
 
 module Cowboy = Fable.Beam.Cowboy.Cowboy
 module CowboyRouter = Fable.Beam.Cowboy.CowboyRouter
+module Application = Fable.Beam.Application
 
 module CowboyFFI =
     /// Atom for the listener name.
     [<Emit("http")>]
     let httpAtom: Atom = nativeOnly
 
-    /// The Erlang module atom implementing the cowboy_handler behaviour.
-    /// Fable >= 5.8 qualifies generated BEAM module names with the source path inside the
-    /// assembly, so src/beam/Middleware.fs compiles to `src_beam_middleware` rather than
-    /// `middleware`. This atom is hand-written, so it has to track that name: move or rename
-    /// Middleware.fs and this must change with it, or Cowboy fails with `undef` on init/2.
-    [<Emit("src_beam_middleware")>]
-    let middlewareAtom: Atom = nativeOnly
+    /// The OTP application to start before the listener. Same text as `httpAtom`'s neighbour by
+    /// coincidence only — one names our listener, this one names cowboy itself.
+    [<Emit("cowboy")>]
+    let cowboyAppAtom: Atom = nativeOnly
 
     /// Cowboy's built-in static-file handler module. We delegate the whole static-serving
     /// problem — mime detection, ETags, Range requests, conditional requests — to it rather
@@ -115,9 +113,12 @@ type WebHostBuilder() =
                 let accessLogger = loggerFactory.CreateLogger("GiraffeHandler")
 
                 // Catch-all: every remaining path → middleware module with the composed pipeline,
-                // the portable service snapshot and the access logger as state.
+                // the portable service snapshot and the access logger as state. The handler module
+                // names itself (`GiraffeHandler.moduleAtom`) rather than being named here: the
+                // generated module name varies with how this project is consumed, and a stale
+                // hand-written atom only surfaces as `undef` at the first request.
                 let catchAllRoute =
-                    CowboyRouter.route "/[...]" CowboyFFI.middlewareAtom (func, serviceSnapshot, accessLogger)
+                    CowboyRouter.route "/[...]" (GiraffeHandler.moduleAtom ()) (func, serviceSnapshot, accessLogger)
 
                 let hostRule =
                     CowboyRouter.hostRule CowboyRouter.wildcard (staticRoutes @ [ catchAllRoute ])
@@ -127,10 +128,22 @@ type WebHostBuilder() =
                 let transportOpts = Cowboy.tcpPort port
                 let protoOpts = Cowboy.protocolOpts dispatch
 
-                Cowboy.startClear CowboyFFI.httpAtom transportOpts protoOpts
-                |> ignore
+                // Cowboy and its dependencies (ranch, cowlib) are OTP applications and must be
+                // running before start_clear. Hosts that boot us from an `erl -eval` often do this
+                // themselves; doing it here means embedding Giraffe in an existing release works
+                // too. ensure_all_started is idempotent, so a host that already did it pays nothing.
+                let hostLogger = loggerFactory.CreateLogger("WebHost")
 
-                Fable.Beam.Io.format "Starting Giraffe on port ~p~n" [ box port ]
+                match Application.ensureAllStarted CowboyFFI.cowboyAppAtom with
+                | Ok _ -> ()
+                | Error reason -> hostLogger.LogError("Could not start the cowboy application: {Reason}", reason)
+
+                // Report through the logger, not stdout: a host may be sharing stdout with a REPL
+                // or another interactive stream. And a discarded start_clear result means a busy
+                // port looks like a successful boot that then serves nothing.
+                match Cowboy.startClear CowboyFFI.httpAtom transportOpts protoOpts with
+                | Ok _ -> hostLogger.LogInformation("Giraffe listening on port {Port}", port)
+                | Error reason -> hostLogger.LogError("Giraffe failed to listen on port {Port}: {Reason}", port, reason)
 
     member this.Configure(configureApp: Action<IApplicationBuilder>) =
         (this :> IWebHostBuilder).Configure(configureApp)


### PR DESCRIPTION
The BEAM backend had only ever been driven by `app/beam`, launched from the Justfile. That hid three defects a real host hits immediately — all found while moving [Synapse](https://github.com/dbrattli/synapse)'s MCP server onto Giraffe, which is the first consumer to embed this library rather than run the sample.

## The handler module atom was hand-written

`WebHost.fs` routed Cowboy at `[<Emit("src_beam_middleware")>]`. Fable derives generated BEAM module names from the source path, and that path depends on how the project is consumed:

| consumed as | `Middleware.fs` becomes |
|---|---|
| standalone (`just build-beam`) | `fable_giraffe_beam_middleware` |
| ProjectReference from `app/beam` | `src_beam_middleware` |
| ProjectReference from another repo | `fable_giraffe_src_beam_middleware` |

Only the middle case matched. Any consumer outside this repo got a listener that started cleanly and then failed every single request with `undef` on `init/2`.

`GiraffeHandler` now names itself:

```fsharp
[<Emit("?MODULE")>]
let private selfModule () : Atom = nativeOnly

let moduleAtom () : Atom = selfModule ()
```

This has to be a **non-inline cross-module call**. `[<Emit>]` expands at the call site, so an atom-valued binding referenced from `WebHost` would expand `?MODULE` inside `..._web_host.erl` and yield the wrong name. `Middleware.fs` therefore moves above `WebHost.fs` in the fsproj — it depends only on `HttpContext`, `Core`/`Helpers`, `PlatformHelpers` and `Fable.Logging`, all of which already precede it.

Verified in the generated Erlang:

```erlang
%% fable_giraffe_src_beam_middleware.erl
module_atom() -> ?MODULE

%% ..._web_host.erl
CatchAllRoute = {<<"/[...]">>, fable_giraffe_src_beam_middleware:module_atom(), {...}}
```

## `Build` never started the `cowboy` application

`app/beam` works because the Justfile runs `application:ensure_all_started(cowboy)` in its `erl -eval` before calling `start()`. A host embedding Giraffe has no such step. `ensure_all_started` is idempotent, so a host that already did it pays nothing.

## `Build` swallowed listener failures and wrote to stdout

`start_clear`'s `Result` was discarded, so a port already in use printed a success line and then served nothing. And the announcement went through `Io.format` to stdout regardless of what else the host has there — a REPL prompt, say. Both now go through the logger, failure included.

## Also

`.gitignore` covered `build/` on the grounds that BEAM output lives there, which holds only while the Justfile drives the build. `rebar3` at the repo root, or a Fable `outDir` following the `apps/` convention, drops generated `.erl` straight into `git status`. Separate commit.

## Testing

- `just test-beam` — **94 passed, 7 skipped** (the pre-existing documented divergences), no change.
- End-to-end against the real consumer: `/health`, MCP `initialize`/`ping`/`tools/list`/`tools/call`, `405` on `GET`/`DELETE`, `/openapi.json` and `/docs` all serve correctly, with zero `undef` in the log.
- **Not run:** the Python and JS suites. No shared code or their fsprojs were touched, but I did not verify that.

## Note on merge

`worktree-upgrade-deps-and-refactor` already carries an equivalent `.gitignore` block, so expect a trivial conflict on those lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
