### PR TITLE
fix: make the published packages Fable-consumable

### DIFF
--- a/Fable.Giraffe.sln
+++ b/Fable.Giraffe.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Giraffe.Python", "src\python\Fable.Giraffe.Python.fsproj", "{0C57A6F8-DE9D-4AF0-B811-9DC6B8F04F80}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Giraffe.Python", "src\Fable.Giraffe.Python.fsproj", "{0C57A6F8-DE9D-4AF0-B811-9DC6B8F04F80}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Giraffe.Beam", "src\beam\Fable.Giraffe.Beam.fsproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Giraffe.Beam", "src\Fable.Giraffe.Beam.fsproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Program", "app\Program.fsproj", "{9B9067B5-6F7C-4DF2-B187-B2762524F0B7}"
 EndProject
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "js", "js", "{A855A773-69E3-BA66-31C8-2FC4DE8D7489}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Giraffe.Js", "src\js\Fable.Giraffe.Js.fsproj", "{96538F57-46A9-45D4-BDE1-23FA1F86E2D4}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fable.Giraffe.Js", "src\Fable.Giraffe.Js.fsproj", "{96538F57-46A9-45D4-BDE1-23FA1F86E2D4}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{0C88DD14-F956-CE84-757C-A364CCF449FC}"
 EndProject

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,5 @@
 build_path := "build"
-src_path := "src/python"
+src_path := "src/Fable.Giraffe.Python.fsproj"
 test_path := "test"
 app_path := "app"
 
@@ -24,7 +24,7 @@ build: clean
     {{fable}} {{src_path}} --exclude Fable.Core --lang Python --outDir {{build_path}}/lib
 
 build-beam: clean-beam
-    {{fable_beam}} src/beam --exclude Fable.Core --lang beam --outDir {{build_path}}/apps/giraffe
+    {{fable_beam}} src/Fable.Giraffe.Beam.fsproj --exclude Fable.Core --lang beam --outDir {{build_path}}/apps/giraffe
     cp rebar.config {{build_path}}/
     cd {{build_path}} && rebar3 compile
 
@@ -41,7 +41,7 @@ app-beam: build-beam
 # Compile the F# library to JavaScript (output: build/js/)
 build-js: clean
     mkdir -p {{build_path}}
-    {{fable}} src/js --exclude Fable.Core --lang javascript --outDir {{build_path}}/js
+    {{fable}} src/Fable.Giraffe.Js.fsproj --exclude Fable.Core --lang javascript --outDir {{build_path}}/js
 
 # Build + start the example app on Node's built-in http server (port 8080)
 app-js: clean
@@ -79,9 +79,9 @@ test-beam:
     cd {{build_path}}/tests-beam && erl -noshell -pa _build/default/lib/*/ebin -eval 'main:main([])'
 
 pack: build
-    dotnet pack -c Release src/python
-    dotnet pack -c Release src/js
-    dotnet pack -c Release src/beam
+    dotnet pack -c Release src/Fable.Giraffe.Python.fsproj
+    dotnet pack -c Release src/Fable.Giraffe.Js.fsproj
+    dotnet pack -c Release src/Fable.Giraffe.Beam.fsproj
 
 format:
     dotnet fantomas src
@@ -94,9 +94,9 @@ setup:
 
 # Create NuGet packages with specific version (used in CI) — Python, JS and BEAM
 pack-version version:
-    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/python
-    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/js
-    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/beam
+    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/Fable.Giraffe.Python.fsproj
+    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/Fable.Giraffe.Js.fsproj
+    dotnet pack -c Release -p:PackageVersion={{version}} -p:InformationalVersion={{version}} src/Fable.Giraffe.Beam.fsproj
 
 # Run EasyBuild.ShipIt for release management (opens/updates the release PR)
 shipit *args:

--- a/app/Program.fsproj
+++ b/app/Program.fsproj
@@ -13,6 +13,6 @@
     <PackageReference Include="Fable.Core" Version="5.2.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\src\python\Fable.Giraffe.Python.fsproj" />
+    <ProjectReference Include="..\src\Fable.Giraffe.Python.fsproj" />
   </ItemGroup>
 </Project>

--- a/app/beam/Program.fsproj
+++ b/app/beam/Program.fsproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Fable.Core" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\beam\Fable.Giraffe.Beam.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Giraffe.Beam.fsproj" />
   </ItemGroup>
 </Project>

--- a/app/js/Program.fsproj
+++ b/app/js/Program.fsproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Fable.Core" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\js\Fable.Giraffe.Js.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Giraffe.Js.fsproj" />
   </ItemGroup>
 </Project>

--- a/perf/beam/Perf.Beam.fsproj
+++ b/perf/beam/Perf.Beam.fsproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Fable.Core" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\beam\Fable.Giraffe.Beam.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Giraffe.Beam.fsproj" />
   </ItemGroup>
 </Project>

--- a/perf/js/Perf.Js.fsproj
+++ b/perf/js/Perf.Js.fsproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Fable.Core" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\js\Fable.Giraffe.Js.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Giraffe.Js.fsproj" />
   </ItemGroup>
 </Project>

--- a/perf/python/Perf.Python.fsproj
+++ b/perf/python/Perf.Python.fsproj
@@ -12,6 +12,6 @@
     <PackageReference Include="Fable.Core" Version="5.2.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\python\Fable.Giraffe.Python.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Giraffe.Python.fsproj" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Giraffe.Beam.fsproj
+++ b/src/Fable.Giraffe.Beam.fsproj
@@ -11,32 +11,38 @@
     <Description>Giraffe for Fable BEAM (Cowboy)</Description>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="PlatformHelpers.fs" />
-    <Compile Include="Json.fs" />
-    <Compile Include="../Helpers.fs" Link="Helpers.fs" />
-    <Compile Include="../Http.fs" Link="Http.fs" />
-    <Compile Include="../ShortGuid.fs" Link="ShortGuid.fs" />
-    <Compile Include="../FormatExpressions.fs" Link="FormatExpressions.fs" />
-    <Compile Include="HttpContext.fs" />
-    <Compile Include="../HttpContextExtensions.fs" Link="HttpContextExtensions.fs" />
-    <Compile Include="../Core.fs" Link="Core.fs" />
-    <Compile Include="../Routing.fs" Link="Routing.fs" />
-    <Compile Include="../Endpoints.fs" Link="Endpoints.fs" />
-    <Compile Include="../Remoting.fs" Link="Remoting.fs" />
-    <Compile Include="../Negotiation.fs" Link="Negotiation.fs" />
-    <Compile Include="../OpenApi.fs" Link="OpenApi.fs" />
-    <Compile Include="../HttpHandler.fs" Link="HttpHandler.fs" />
-    <Compile Include="../HttpStatusCodeHandlers.fs" Link="HttpStatusCodeHandlers.fs" />
-    <Compile Include="../Logging.fs" Link="Logging.fs" />
+    <Compile Include="beam/PlatformHelpers.fs" />
+    <Compile Include="beam/Json.fs" />
+    <Compile Include="Helpers.fs" />
+    <Compile Include="Http.fs" />
+    <Compile Include="ShortGuid.fs" />
+    <Compile Include="FormatExpressions.fs" />
+    <Compile Include="beam/HttpContext.fs" />
+    <Compile Include="HttpContextExtensions.fs" />
+    <Compile Include="Core.fs" />
+    <Compile Include="Routing.fs" />
+    <Compile Include="Endpoints.fs" />
+    <Compile Include="Remoting.fs" />
+    <Compile Include="Negotiation.fs" />
+    <Compile Include="OpenApi.fs" />
+    <Compile Include="HttpHandler.fs" />
+    <Compile Include="HttpStatusCodeHandlers.fs" />
+    <Compile Include="Logging.fs" />
     <!-- Middleware before WebHost: WebHost routes Cowboy to GiraffeHandler.moduleAtom(), which
-         has to be defined in the module it names. Middleware itself depends only on HttpContext,
-         Core/Helpers, PlatformHelpers and Logging, all of which precede it. -->
-    <Compile Include="Middleware.fs" />
-    <Compile Include="WebHost.fs" />
+         has to be defined in the module it names. -->
+    <Compile Include="beam/Middleware.fs" />
+    <Compile Include="beam/WebHost.fs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath="\" />
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Fable compiles from the sources under fable/, not the DLL. Every Compile path must stay
+         inside this project's directory or it cannot be packed there; that is why this fsproj
+         lives at src/ rather than src/beam/. -->
+    <Content Include="$(MSBuildProjectFile); *.fs; *.fsi" PackagePath="fable\" />
+    <Content Include="beam\*.fs; beam\*.fsi" PackagePath="fable\beam\" />
   </ItemGroup>
   <ItemGroup>
     <!-- Pinned explicitly: the SDK's implicit FSharp.Core is older than the one

--- a/src/Fable.Giraffe.Beam.fsproj
+++ b/src/Fable.Giraffe.Beam.fsproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/dbrattli/Fable.Giraffe</RepositoryUrl>
-    <PackageTags>web;fsharp;beam;erlang;giraffe;fable;cowboy</PackageTags>
+    <PackageTags>fsharp;fable;fable-library;fable-beam;giraffe;web;erlang;cowboy</PackageTags>
     <Description>Giraffe for Fable BEAM (Cowboy)</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fable.Giraffe.Js.fsproj
+++ b/src/Fable.Giraffe.Js.fsproj
@@ -11,30 +11,30 @@
     <Description>Giraffe for Fable JavaScript (Node)</Description>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="PlatformHelpers.fs" />
-    <Compile Include="Json.fs" />
-    <Compile Include="../Helpers.fs" Link="Helpers.fs" />
-    <Compile Include="../Http.fs" Link="Http.fs" />
-    <Compile Include="../ShortGuid.fs" Link="ShortGuid.fs" />
-    <Compile Include="../FormatExpressions.fs" Link="FormatExpressions.fs" />
+    <Compile Include="js/PlatformHelpers.fs" />
+    <Compile Include="js/Json.fs" />
+    <Compile Include="Helpers.fs" />
+    <Compile Include="Http.fs" />
+    <Compile Include="ShortGuid.fs" />
+    <Compile Include="FormatExpressions.fs" />
     <!-- Node-native context (wraps http req/res directly; no dependency on other backends) -->
-    <Compile Include="HttpContext.fs" />
-    <Compile Include="../HttpContextExtensions.fs" Link="HttpContextExtensions.fs" />
-    <Compile Include="../Core.fs" Link="Core.fs" />
-    <Compile Include="../Routing.fs" Link="Routing.fs" />
-    <Compile Include="../Endpoints.fs" Link="Endpoints.fs" />
-    <Compile Include="../Remoting.fs" Link="Remoting.fs" />
-    <Compile Include="../Negotiation.fs" Link="Negotiation.fs" />
-    <Compile Include="../OpenApi.fs" Link="OpenApi.fs" />
-    <Compile Include="../HttpHandler.fs" Link="HttpHandler.fs" />
-    <Compile Include="../HttpStatusCodeHandlers.fs" Link="HttpStatusCodeHandlers.fs" />
-    <Compile Include="Server.fs" />
-    <Compile Include="../Logging.fs" Link="Logging.fs" />
-    <Compile Include="WebHost.fs" />
+    <Compile Include="js/HttpContext.fs" />
+    <Compile Include="HttpContextExtensions.fs" />
+    <Compile Include="Core.fs" />
+    <Compile Include="Routing.fs" />
+    <Compile Include="Endpoints.fs" />
+    <Compile Include="Remoting.fs" />
+    <Compile Include="Negotiation.fs" />
+    <Compile Include="OpenApi.fs" />
+    <Compile Include="HttpHandler.fs" />
+    <Compile Include="HttpStatusCodeHandlers.fs" />
+    <Compile Include="js/Server.fs" />
+    <Compile Include="Logging.fs" />
+    <Compile Include="js/WebHost.fs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath="\" />
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <!-- Pinned explicitly: the SDK's implicit FSharp.Core is older than the one
@@ -49,6 +49,8 @@
     <PackageReference Include="Fable.Logging" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
+    <!-- See Fable.Giraffe.Beam.fsproj. -->
+    <Content Include="$(MSBuildProjectFile); *.fs; *.fsi" PackagePath="fable\" />
+    <Content Include="js\*.fs; js\*.fsi" PackagePath="fable\js\" />
   </ItemGroup>
 </Project>

--- a/src/Fable.Giraffe.Js.fsproj
+++ b/src/Fable.Giraffe.Js.fsproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/dbrattli/Fable.Giraffe</RepositoryUrl>
-    <PackageTags>web;fsharp;javascript;node;giraffe;fable;express;connect</PackageTags>
+    <PackageTags>fsharp;fable;fable-library;fable-javascript;giraffe;web;node</PackageTags>
     <Description>Giraffe for Fable JavaScript (Node)</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fable.Giraffe.Python.fsproj
+++ b/src/Fable.Giraffe.Python.fsproj
@@ -7,7 +7,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <RepositoryUrl>https://github.com/dbrattli/Fable.Giraffe</RepositoryUrl>
-    <PackageTags>web;fsharp;python;giraffe;fable;fable-library;fable-python</PackageTags>
+    <PackageTags>fsharp;fable;fable-library;fable-python;giraffe;web;python;asgi</PackageTags>
     <Description>Giraffe for Fable Python</Description>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Fable.Giraffe.Python.fsproj
+++ b/src/Fable.Giraffe.Python.fsproj
@@ -11,30 +11,30 @@
     <Description>Giraffe for Fable Python</Description>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="PlatformHelpers.fs" />
-    <Compile Include="Json.fs" />
-    <Compile Include="../Helpers.fs" Link="Helpers.fs" />
-    <Compile Include="../Http.fs" Link="Http.fs" />
-    <Compile Include="../ShortGuid.fs" Link="ShortGuid.fs" />
-    <Compile Include="../FormatExpressions.fs" Link="FormatExpressions.fs" />
-    <Compile Include="HttpContext.fs" />
-    <Compile Include="../HttpContextExtensions.fs" Link="HttpContextExtensions.fs" />
-    <Compile Include="../Core.fs" Link="Core.fs" />
-    <Compile Include="../Routing.fs" Link="Routing.fs" />
-    <Compile Include="../Endpoints.fs" Link="Endpoints.fs" />
-    <Compile Include="../Remoting.fs" Link="Remoting.fs" />
-    <Compile Include="../Negotiation.fs" Link="Negotiation.fs" />
-    <Compile Include="../OpenApi.fs" Link="OpenApi.fs" />
-    <Compile Include="../HttpHandler.fs" Link="HttpHandler.fs" />
-    <Compile Include="../HttpStatusCodeHandlers.fs" Link="HttpStatusCodeHandlers.fs" />
-    <Compile Include="../Logging.fs" Link="Logging.fs" />
-    <Compile Include="WebHost.fs" />
-    <Compile Include="Middleware.fs" />
-    <Compile Include="StaticFiles.fs" />
+    <Compile Include="python/PlatformHelpers.fs" />
+    <Compile Include="python/Json.fs" />
+    <Compile Include="Helpers.fs" />
+    <Compile Include="Http.fs" />
+    <Compile Include="ShortGuid.fs" />
+    <Compile Include="FormatExpressions.fs" />
+    <Compile Include="python/HttpContext.fs" />
+    <Compile Include="HttpContextExtensions.fs" />
+    <Compile Include="Core.fs" />
+    <Compile Include="Routing.fs" />
+    <Compile Include="Endpoints.fs" />
+    <Compile Include="Remoting.fs" />
+    <Compile Include="Negotiation.fs" />
+    <Compile Include="OpenApi.fs" />
+    <Compile Include="HttpHandler.fs" />
+    <Compile Include="HttpStatusCodeHandlers.fs" />
+    <Compile Include="Logging.fs" />
+    <Compile Include="python/WebHost.fs" />
+    <Compile Include="python/Middleware.fs" />
+    <Compile Include="python/StaticFiles.fs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\LICENSE" Pack="true" Visible="false" PackagePath="\" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE" Pack="true" Visible="false" PackagePath="\" />
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <!-- Pinned explicitly: the SDK's implicit FSharp.Core is older than the one
@@ -51,6 +51,10 @@
     <PackageReference Include="Fable.Python" Version="5.4.0" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\..\pyproject.toml; *.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
+    <!-- See src/beam: the shared ../*.fs were never packaged, and `**\*.fs` swept in obj/.
+         pyproject.toml stays at fable/; no Compile item refers to it. -->
+    <Content Include="..\pyproject.toml" PackagePath="fable\" />
+    <Content Include="$(MSBuildProjectFile); *.fs; *.fsi" PackagePath="fable\" />
+    <Content Include="python\*.fs; python\*.fsi" PackagePath="fable\python\" />
   </ItemGroup>
 </Project>

--- a/test/beam/Fable.Giraffe.Tests.Beam.fsproj
+++ b/test/beam/Fable.Giraffe.Tests.Beam.fsproj
@@ -24,6 +24,6 @@
     <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.24" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\beam\Fable.Giraffe.Beam.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Giraffe.Beam.fsproj" />
   </ItemGroup>
 </Project>

--- a/test/js/Tests.fsproj
+++ b/test/js/Tests.fsproj
@@ -22,6 +22,6 @@
     <PackageReference Include="Scriptorium.Nib" Version="0.4.1" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\js\Fable.Giraffe.Js.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Giraffe.Js.fsproj" />
   </ItemGroup>
 </Project>

--- a/test/python/Fable.Giraffe.Tests.Python.fsproj
+++ b/test/python/Fable.Giraffe.Tests.Python.fsproj
@@ -24,6 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\python\Fable.Giraffe.Python.fsproj" />
+    <ProjectReference Include="..\..\src\Fable.Giraffe.Python.fsproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fable compiles a package from the F# sources under `fable/`, not from the DLL. A package without them fails silently — it type-checks under `dotnet build` and emits **no code** under `dotnet fable`. All three packages were broken, in two different ways.

- **`Fable.Giraffe.Beam` shipped no sources at all.** It never had the `Content` item that js and python have.
- **js and python had one, but it didn't work.** `**\*.fs` is project-relative, so none of the 14 shared files one level up were included — the packaged fsproj pointed at `../Core.fs` and friends that weren't in the package. The same glob swept `obj/` AssemblyInfo in.

## Why this isn't a missing line

Three attempts, each ruled out empirically:

| packed layout | result |
|---|---|
| fsproj at `fable/beam/`, shared at `fable/` | Fable never finds the fsproj; compiles from the DLL, generates nothing |
| fsproj at `fable/`, shared at package root | Fable inlines them, then: `error FABLE: Cannot locate the OTP app directory ... expected output path to contain a 'fable_modules/<package>' segment` |
| everything under `fable/` | ✅ works |

The third requires every `Compile` path to resolve inside the packed tree, which means **no fsproj can reference sources outside its own directory**. Both sibling repos already satisfy this — `Fable.Beam` by having self-contained packages with no shared sources, `Fable.Actor` by being a single multi-target project. Giraffe was the only one violating it, and the only one whose package didn't work.

## The change

The three backend projects move from `src/<target>/` up to `src/`, where the shared files already are. **Only the fsprojs move** — the backend `.fs` files stay in `src/beam`, `src/js`, `src/python` and are now referenced as `beam/WebHost.fs` etc. Every `Compile` path becomes project-relative, and each project packs its own sources with an explicit per-backend glob rather than `**\*.fs`, so the three packages no longer swallow each other's files:

```xml
<Content Include="$(MSBuildProjectFile); *.fs; *.fsi" PackagePath="fable\" />
<Content Include="beam\*.fs; beam\*.fsi" PackagePath="fable\beam\" />
```

Generated BEAM module names change again as a result (`fable_giraffe_beam_beam_middleware` under the package). Nothing needs updating for it — the handler names itself via `?MODULE` as of #76. That's now four distinct names the same source has produced; pinning it by hand was never going to hold.

## Testing

Packed `Fable.Giraffe.Beam` to a local feed and consumed it from a throwaway project:

- Fable parses **71 source files** — identical to the ProjectReference path (it was 52, compiling against the DLL, before this).
- `rebar3 compile` clean, and the result serves `200 OK` on BEAM with `WebHost - Giraffe listening on port 8080`.
- Giraffe lands as its own OTP app in `fable_modules/` rather than being inlined into the consumer — also an improvement over the ProjectReference path, which duplicates it into every consuming app.

All three suites unchanged: **BEAM 94 passed / 7 skipped, JS 100 / 1 skipped, Python 101**. `dotnet build` clean on all three projects.

## Notes

- `PackageTags` are normalised in a follow-up commit. Beam and js never carried the ecosystem tags; python already had them. All three now read `fsharp;fable;fable-library;fable-<target>;...`. `fable-library` rather than `fable-binding`: Fable.Python and Fable.Beam bind platform APIs, while Fable.Logging and Fable.Reactive are F# libraries compiled to several targets — Giraffe is the latter. Purely nuget.org discovery metadata; no effect on the fix above.
- Three fsprojs now share `src/`. Legal, and the Justfile addresses them by explicit path, but `dotnet build src/` is no longer unambiguous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

