### PR TITLE
docs: fix the three XML comment warnings in Core.fs

### DIFF
--- a/src/Core.fs
+++ b/src/Core.fs
@@ -242,6 +242,8 @@ module Core =
     /// Additive rather than a change to <c>bindJson</c>: apps opt in where they want it.
     /// </remarks>
     /// <param name="f">A function which accepts an object of type 'T and returns a <see cref="HttpHandler"/> function.</param>
+    /// <param name="next"></param>
+    /// <param name="ctx"></param>
     /// <typeparam name="'T"></typeparam>
     /// <returns>A Giraffe <see cref="HttpHandler"/> function which can be composed into a bigger web application.</returns>
     let inline validateJson<'T> (f: 'T -> HttpHandler) : HttpHandler =
@@ -319,7 +321,6 @@ module Core =
     /// It also sets the HTTP Content-Type header to application/json and sets the Content-Length header accordingly.
     /// </summary>
     /// <param name="dataObj">The object to be send back to the client.</param>
-    /// <param name="ctx"></param>
     /// <typeparam name="'T"></typeparam>
     /// <returns>A Giraffe <see cref="HttpHandler" /> function which can be composed into a bigger web application.</returns>
     /// <remarks>


### PR DESCRIPTION
Clears the `FS3390` warnings in the release build. Two distinct causes, both in `src/Core.fs`.

**`validateJson` (L233) — two missing entries.** `HttpHandler` expands to `HttpFunc -> HttpContext -> HttpFuncResult`, and the body is directly a lambda, so F# sees three curried parameters while the doc comment named only `f`. Its sibling `bindJson` already carries the empty `next`/`ctx` entries — `validateJson` was added later and omitted them. Now matches.

**`json` (L317) — one entry too many.** It documented a `ctx` parameter it doesn't have. The `let bytes = ...` hoist makes the lambda a returned value rather than further curried parameters, so `dataObj` is the only parameter. Same shape as `text` and `htmlFile`, neither of which documents `ctx`.

Each warning is reported once per backend project, which is why three warnings show up as nine lines in the release log.

## Testing

- All three projects build `-c Release` with **0 warnings** (was 3 each).
- `just test-beam`: 94 passed / 7 skipped, unchanged.

Comment-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
