### PR TITLE
feat: add portable MCP protocol handling across Fable targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,41 @@ A malformed body answers 400 with field-level errors; an exception raised by an
 API method answers 500 without leaking it (`Remoting.withErrorHandler` replaces
 that default).
 
+## Model Context Protocol
+
+`Fable.Giraffe.Mcp` provides a portable JSON-RPC/MCP core on Python, JavaScript,
+and BEAM. It parses one MCP message, preserves string, numeric, and null request
+IDs and arbitrary tool arguments, and handles initialization, ping, tool discovery,
+tool-call validation, protocol errors, and accepted notifications. The application
+retains ownership of tool execution and policy:
+
+```fsharp
+let server = {
+    Info = { Name = "example"; Version = "1.0.0" }
+    ProtocolVersions = [ "2025-11-25" ]
+}
+
+match Mcp.handleRequest server tools requestBody with
+| Mcp.NoResponse -> "" // accepted notification
+| Mcp.Respond json -> json
+| Mcp.CallTool(id, call) ->
+    execute call
+    |> Mcp.completeToolCall id
+```
+
+`completeToolCall` is a convenience for a single text content block. Use
+`buildResult` with a complete result JSON object for images, resources,
+`structuredContent`, metadata, or application-implemented MCP methods.
+
+`streamableHttp` implements the synchronous POST/JSON subset of Streamable HTTP:
+JSON-RPC responses become HTTP 200 `application/json`, while accepted
+notifications become an empty HTTP 202 response. Compose authentication, Origin
+and Accept validation, the `MCP-Protocol-Version` header, sessions, timeouts, and
+GET/SSE behavior at the application boundary. MCP transport bodies contain one
+message; JSON-RPC batches are rejected. Lifecycle state enforcement is likewise
+left to a session-aware application—the core performs initialization negotiation
+but does not remember whether a client has sent `notifications/initialized`.
+
 ## Prerequisites
 
 - .NET SDK 8+

--- a/src/Fable.Giraffe.Beam.fsproj
+++ b/src/Fable.Giraffe.Beam.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="beam/HttpContext.fs" />
     <Compile Include="HttpContextExtensions.fs" />
     <Compile Include="Core.fs" />
+    <Compile Include="Mcp.fs" />
     <Compile Include="Routing.fs" />
     <Compile Include="Endpoints.fs" />
     <Compile Include="Remoting.fs" />

--- a/src/Fable.Giraffe.Js.fsproj
+++ b/src/Fable.Giraffe.Js.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="js/HttpContext.fs" />
     <Compile Include="HttpContextExtensions.fs" />
     <Compile Include="Core.fs" />
+    <Compile Include="Mcp.fs" />
     <Compile Include="Routing.fs" />
     <Compile Include="Endpoints.fs" />
     <Compile Include="Remoting.fs" />

--- a/src/Fable.Giraffe.Python.fsproj
+++ b/src/Fable.Giraffe.Python.fsproj
@@ -20,6 +20,7 @@
     <Compile Include="python/HttpContext.fs" />
     <Compile Include="HttpContextExtensions.fs" />
     <Compile Include="Core.fs" />
+    <Compile Include="Mcp.fs" />
     <Compile Include="Routing.fs" />
     <Compile Include="Endpoints.fs" />
     <Compile Include="Remoting.fs" />

--- a/src/Mcp.fs
+++ b/src/Mcp.fs
@@ -1,0 +1,220 @@
+(**
+# MCP — reusable Model Context Protocol handling
+
+Implements the transport-independent JSON-RPC request/response core used by an MCP
+Streamable HTTP endpoint. Applications provide server metadata and tools, execute
+the `CallTool` action, and feed the result back through `completeToolCall`.
+*)
+
+module Fable.Giraffe.Mcp
+
+open System.Text
+open Fable.Giraffe.Json
+
+type ServerInfo = { Name: string; Version: string }
+
+type Server =
+    { Info: ServerInfo
+      ProtocolVersions: string list }
+
+type Tool =
+    { Name: string
+      Description: string
+      InputSchemaJson: string }
+
+type ToolCall = { Name: string; ArgumentsJson: string }
+
+type ToolResult = { Content: string; IsError: bool }
+
+type RequestId = private RequestId of obj
+
+type Action =
+    | NoResponse
+    | Respond of string
+    | CallTool of RequestId * ToolCall
+
+let private str (value: string) : obj = box value
+let private boolValue (value: bool) : obj = box value
+let private intValue (value: int) : obj = box value
+
+let private response (id: obj) (field: string) (value: obj) : string =
+    rawObject [ "jsonrpc", str "2.0"; "id", id; field, value ]
+    |> rawToJson
+
+/// Complete a request with an arbitrary JSON result. This is the extensibility
+/// path for structured tool content and MCP methods implemented by an application.
+let buildResult (RequestId id) (resultJson: string) : string =
+    response id "result" (deserialize resultJson)
+
+let buildErrorWithId (id: obj) (code: int) (message: string) : string =
+    let error = rawObject [ "code", intValue code; "message", str message ]
+    response id "error" error
+
+let buildError (id: RequestId) (code: int) (message: string) : string =
+    let (RequestId rawId) = id
+    buildErrorWithId rawId code message
+
+let buildProtocolError (code: int) (message: string) : string = buildErrorWithId rawNull code message
+
+let private buildErrorWithData (id: obj) (code: int) (message: string) (data: obj) : string =
+    let error =
+        rawObject [ "code", intValue code; "message", str message; "data", data ]
+
+    response id "error" error
+
+let private tryProperty (key: string) (value: obj) : obj option =
+    if rawContains key value then
+        Some(rawGet key value)
+    else
+        None
+
+let private tryStringProperty (key: string) (value: obj) : string option =
+    match tryProperty key value with
+    | Some field when rawIsString field -> Some(rawAsString field)
+    | _ -> None
+
+let private initializeResult (server: Server) (version: string) : obj =
+    rawObject
+        [ "protocolVersion", str version
+          "capabilities", rawObject [ "tools", rawObject [] ]
+          "serverInfo", rawObject [ "name", str server.Info.Name; "version", str server.Info.Version ] ]
+
+let private toolJson (tool: Tool) : obj =
+    rawObject
+        [ "name", str tool.Name
+          "description", str tool.Description
+          "inputSchema", deserialize tool.InputSchemaJson ]
+
+let private toolsResult (tools: Tool list) : obj =
+    rawObject [ "tools", tools |> List.map toolJson |> rawArray ]
+
+/// Parse and dispatch one JSON-RPC request. Batches are deliberately rejected because
+/// MCP removed batching in protocol revision 2025-06-18.
+let handleRequest (server: Server) (tools: Tool list) (body: string) : Action =
+    let parsed =
+        try
+            Some(deserialize body)
+        with _ ->
+            None
+
+    match parsed with
+    | None -> Respond(buildProtocolError -32700 "Parse error")
+    | Some json when rawIsArray json -> Respond(buildProtocolError -32600 "Batch requests are not supported")
+    | Some json when not (rawIsMap json) -> Respond(buildProtocolError -32600 "Invalid Request")
+    | Some json ->
+        let id = tryProperty "id" json
+
+        let validId =
+            id
+            |> Option.forall (fun value ->
+                rawIsString value
+                || rawIsNumber value
+                || rawIsNull value)
+
+        match validId, tryStringProperty "jsonrpc" json, tryStringProperty "method" json with
+        | false, _, _ -> Respond(buildProtocolError -32600 "Invalid Request")
+        | true, Some "2.0", Some methodName ->
+            match id with
+            | None -> NoResponse
+            | Some rawId ->
+                let requestId = RequestId rawId
+
+                match methodName with
+                | "initialize" ->
+                    let initializeParams =
+                        tryProperty "params" json
+                        |> Option.filter rawIsMap
+
+                    let requested =
+                        initializeParams
+                        |> Option.bind (tryStringProperty "protocolVersion")
+
+                    let validClient =
+                        initializeParams
+                        |> Option.bind (tryProperty "clientInfo")
+                        |> Option.exists (fun client ->
+                            rawIsMap client
+                            && tryStringProperty "name" client |> Option.isSome
+                            && tryStringProperty "version" client
+                               |> Option.isSome)
+
+                    let validCapabilities =
+                        initializeParams
+                        |> Option.bind (tryProperty "capabilities")
+                        |> Option.exists rawIsMap
+
+                    match requested, validClient, validCapabilities with
+                    | _, false, _
+                    | _, _, false
+                    | None, _, _ -> Respond(buildError requestId -32602 "Invalid params for initialize")
+                    | Some version, true, true when List.contains version server.ProtocolVersions ->
+                        Respond(response rawId "result" (initializeResult server version))
+                    | Some version, true, true ->
+                        let data =
+                            rawObject
+                                [ "supported",
+                                  server.ProtocolVersions
+                                  |> List.map str
+                                  |> rawArray
+                                  "requested", str version ]
+
+                        Respond(buildErrorWithData rawId -32602 "Unsupported protocol version" data)
+                | "ping" -> Respond(response rawId "result" (rawObject []))
+                | "tools/list" -> Respond(response rawId "result" (toolsResult tools))
+                | "tools/call" ->
+                    match tryProperty "params" json with
+                    | Some parameters when rawIsMap parameters ->
+                        let arguments =
+                            tryProperty "arguments" parameters
+                            |> Option.defaultWith (fun () -> rawObject [])
+
+                        match tryStringProperty "name" parameters with
+                        | Some name when rawIsMap arguments ->
+                            if
+                                tools
+                                |> List.exists (fun tool -> tool.Name = name)
+                            then
+                                CallTool(
+                                    requestId,
+                                    { Name = name
+                                      ArgumentsJson = rawToJson arguments }
+                                )
+                            else
+                                Respond(buildError requestId -32602 $"Unknown tool: %s{name}")
+                        | _ -> Respond(buildError requestId -32602 "Invalid params for tools/call")
+                    | _ -> Respond(buildError requestId -32602 "Invalid params for tools/call")
+                | _ -> Respond(buildError requestId -32601 $"Method not found: %s{methodName}")
+        | _ -> Respond(buildErrorWithId (id |> Option.defaultValue rawNull) -32600 "Invalid Request")
+
+/// Complete a tool call with one text content block. Use `buildResult` when the
+/// application needs images, audio, resource links, structured content or metadata.
+let completeToolCall (id: RequestId) (result: ToolResult) : string =
+    let content =
+        rawArray [ rawObject [ "type", str "text"; "text", str result.Content ] ]
+
+    let fields =
+        if result.IsError then
+            [ "content", content; "isError", boolValue true ]
+        else
+            [ "content", content ]
+
+    buildResult id (rawObject fields |> rawToJson)
+
+/// The POST/JSON subset of Streamable HTTP for a synchronous MCP dispatcher.
+/// An empty result represents an accepted notification and is returned as HTTP 202.
+/// Authentication, Origin/Accept/version-header validation, sessions, GET/SSE and
+/// timeouts remain transport/application policy and can be composed around this handler.
+let streamableHttp (dispatch: string -> string) : HttpHandler =
+    fun (_: HttpFunc) (ctx: HttpContext) ->
+        task {
+            let! body = ctx.ReadBodyFromRequestAsync()
+            let result = dispatch body
+
+            if result = "" then
+                ctx.SetStatusCode 202
+                return! ctx.WriteBytesAsync [||]
+            else
+                ctx.SetStatusCode 200
+                ctx.SetContentType "application/json"
+                return! ctx.WriteBytesAsync(Encoding.UTF8.GetBytes result)
+        }

--- a/src/beam/Json.fs
+++ b/src/beam/Json.fs
@@ -51,6 +51,23 @@ let serializeAs (t: System.Type) (value: obj) : string = (codecFor t).encode val
 /// an F# type.
 let deserialize (s: string) : obj = parseRaw s
 
+/// Raw JSON operations used by protocol adapters which must preserve arbitrary values.
+let rawContains (key: string) (value: obj) : bool = beam.ContainsKey(value, key)
+let rawGet (key: string) (value: obj) : obj = beam.Get(value, key)
+let rawIsArray (value: obj) : bool = beam.IsArray value
+let rawIsMap (value: obj) : bool = beam.IsMap value
+let rawIsString (value: obj) : bool = beam.IsString value
+let rawIsNumber (value: obj) : bool = beam.IsInt value || beam.IsFloat value
+let rawIsNull (value: obj) : bool = beam.IsNull value
+let rawAsString (value: obj) : string = beam.AsString value
+let rawToJson (value: obj) : string = beam.Stringify value
+let rawNull: obj = beam.Null
+
+let rawObject (fields: (string * obj) list) : obj =
+    Fable.TypedJson.Json.Encode.object beam fields
+
+let rawArray (items: obj list) : obj = beam.BuildArray items
+
 /// Decode into `'T`, accumulating a per-field error list rather than throwing.
 let inline tryDeserialize<'T> (s: string) : Result<'T, FieldError list> = (codec<'T> ()).decode (parseRaw s)
 

--- a/src/js/Json.fs
+++ b/src/js/Json.fs
@@ -51,6 +51,23 @@ let serializeAs (t: System.Type) (value: obj) : string = (codecFor t).encode val
 /// an F# type.
 let deserialize (s: string) : obj = parseRaw s
 
+/// Raw JSON operations used by protocol adapters which must preserve arbitrary values.
+let rawContains (key: string) (value: obj) : bool = js.ContainsKey(value, key)
+let rawGet (key: string) (value: obj) : obj = js.Get(value, key)
+let rawIsArray (value: obj) : bool = js.IsArray value
+let rawIsMap (value: obj) : bool = js.IsMap value
+let rawIsString (value: obj) : bool = js.IsString value
+let rawIsNumber (value: obj) : bool = js.IsInt value || js.IsFloat value
+let rawIsNull (value: obj) : bool = js.IsNull value
+let rawAsString (value: obj) : string = js.AsString value
+let rawToJson (value: obj) : string = js.Stringify value
+let rawNull: obj = js.Null
+
+let rawObject (fields: (string * obj) list) : obj =
+    Fable.TypedJson.Json.Encode.object js fields
+
+let rawArray (items: obj list) : obj = js.BuildArray items
+
 /// Decode into `'T`, accumulating a per-field error list rather than throwing.
 let inline tryDeserialize<'T> (s: string) : Result<'T, FieldError list> = (codec<'T> ()).decode (parseRaw s)
 

--- a/src/python/Json.fs
+++ b/src/python/Json.fs
@@ -51,6 +51,26 @@ let serializeAs (t: System.Type) (value: obj) : string = (codecFor t).encode val
 /// an F# type.
 let deserialize (s: string) : obj = parseRaw s
 
+/// Raw JSON operations used by protocol adapters which must preserve arbitrary values.
+let rawContains (key: string) (value: obj) : bool = python.ContainsKey(value, key)
+let rawGet (key: string) (value: obj) : obj = python.Get(value, key)
+let rawIsArray (value: obj) : bool = python.IsArray value
+let rawIsMap (value: obj) : bool = python.IsMap value
+let rawIsString (value: obj) : bool = python.IsString value
+
+let rawIsNumber (value: obj) : bool =
+    python.IsInt value || python.IsFloat value
+
+let rawIsNull (value: obj) : bool = python.IsNull value
+let rawAsString (value: obj) : string = python.AsString value
+let rawToJson (value: obj) : string = python.Stringify value
+let rawNull: obj = python.Null
+
+let rawObject (fields: (string * obj) list) : obj =
+    Fable.TypedJson.Json.Encode.object python fields
+
+let rawArray (items: obj list) : obj = python.BuildArray items
+
 /// Decode into `'T`, accumulating a per-field error list rather than throwing.
 let inline tryDeserialize<'T> (s: string) : Result<'T, FieldError list> = (codec<'T> ()).decode (parseRaw s)
 

--- a/test/beam/Fable.Giraffe.Tests.Beam.fsproj
+++ b/test/beam/Fable.Giraffe.Tests.Beam.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="../shared/EndpointTests.fs" />
     <Compile Include="../shared/OpenApiTests.fs" />
     <Compile Include="../shared/RemotingTests.fs" />
+    <Compile Include="../shared/McpTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/beam/Main.fs
+++ b/test/beam/Main.fs
@@ -13,4 +13,5 @@ let main _ =
           RoutingTests.tests
           EndpointTests.tests
           OpenApiTests.tests
-          RemotingTests.tests ]
+          RemotingTests.tests
+          McpTests.tests ]

--- a/test/js/Main.fs
+++ b/test/js/Main.fs
@@ -12,4 +12,5 @@ let main _ =
           RoutingTests.tests
           EndpointTests.tests
           OpenApiTests.tests
-          RemotingTests.tests ]
+          RemotingTests.tests
+          McpTests.tests ]

--- a/test/js/Tests.fsproj
+++ b/test/js/Tests.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="../shared/EndpointTests.fs" />
     <Compile Include="../shared/OpenApiTests.fs" />
     <Compile Include="../shared/RemotingTests.fs" />
+    <Compile Include="../shared/McpTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/python/Fable.Giraffe.Tests.Python.fsproj
+++ b/test/python/Fable.Giraffe.Tests.Python.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="../shared/EndpointTests.fs" />
     <Compile Include="../shared/OpenApiTests.fs" />
     <Compile Include="../shared/RemotingTests.fs" />
+    <Compile Include="../shared/McpTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/test/python/Main.fs
+++ b/test/python/Main.fs
@@ -11,4 +11,5 @@ let main _ =
           RoutingTests.tests
           EndpointTests.tests
           OpenApiTests.tests
-          RemotingTests.tests ]
+          RemotingTests.tests
+          McpTests.tests ]

--- a/test/shared/McpTests.fs
+++ b/test/shared/McpTests.fs
@@ -1,0 +1,259 @@
+module Fable.Giraffe.Tests.McpTests
+
+open System.Text
+open Scriptorium.Nib.Assertion
+open type Scriptorium.Quill.Test
+
+open Fable.Giraffe
+open Fable.Giraffe.Json
+open Fable.Giraffe.Mcp
+
+let private server =
+    { Info =
+        { Name = "test-server"
+          Version = "1.2.3" }
+      ProtocolVersions = [ "2025-03-26"; "2025-11-25" ] }
+
+let private tools =
+    [ { Name = "echo"
+        Description = "Echo text"
+        InputSchemaJson = """{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}""" } ]
+
+let private responseJson =
+    function
+    | Respond json -> json
+    | other -> failwith $"Expected a response, got %A{other}"
+
+let private field key json = json |> deserialize |> rawGet key
+
+let private errorCode json =
+    json
+    |> responseJson
+    |> field "error"
+    |> rawGet "code"
+    |> rawToJson
+
+let private responseId json =
+    json |> responseJson |> field "id" |> rawToJson
+
+let tests =
+    testList (
+        "MCP",
+        [ test (
+              "initialize negotiates a supported protocol version",
+              fun _ ->
+                  let json =
+                      handleRequest
+                          server
+                          tools
+                          """{"jsonrpc":"2.0","id":"a","method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}"""
+                      |> responseJson
+
+                  let result = field "result" json
+                  assertThat (result |> rawGet "protocolVersion" |> rawAsString) (isEqualTo "2025-03-26")
+
+                  assertThat
+                      (result
+                       |> rawGet "serverInfo"
+                       |> rawGet "name"
+                       |> rawAsString)
+                      (isEqualTo "test-server")
+          )
+
+          test (
+              "tools/call returns an application action and preserves arguments",
+              fun _ ->
+                  match
+                      handleRequest
+                          server
+                          tools
+                          """{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hello"}}}"""
+                  with
+                  | CallTool(id, call) ->
+                      assertThat call.Name (isEqualTo "echo")
+
+                      assertThat
+                          (call.ArgumentsJson
+                           |> deserialize
+                           |> rawGet "text"
+                           |> rawAsString)
+                          (isEqualTo "hello")
+
+                      let response = completeToolCall id { Content = "hello"; IsError = false }
+                      let result = field "result" response
+                      assertThat (result |> rawGet "content" |> rawIsArray) isTrue
+                  | other -> failwith $"Expected a tool call, got %A{other}"
+          )
+
+          test (
+              "tools/call defaults omitted arguments to an empty object",
+              fun _ ->
+                  match handleRequest server tools """{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"echo"}}""" with
+                  | CallTool(_, call) -> assertThat call.ArgumentsJson (isEqualTo (rawObject [] |> rawToJson))
+                  | other -> failwith $"Expected a tool call, got %A{other}"
+          )
+
+          test (
+              "string numeric and null IDs are preserved",
+              fun _ ->
+                  assertThat
+                      (handleRequest server tools """{"jsonrpc":"2.0","id":"a\"b","method":"ping"}"""
+                       |> responseId)
+                      (isEqualTo "\"a\\\"b\"")
+
+                  assertThat
+                      (handleRequest server tools """{"jsonrpc":"2.0","id":42,"method":"ping"}"""
+                       |> responseId)
+                      (isEqualTo "42")
+
+                  assertThat
+                      (handleRequest server tools """{"jsonrpc":"2.0","id":null,"method":"ping"}"""
+                       |> responseId)
+                      (isEqualTo "null")
+          )
+
+          test (
+              "structured IDs are rejected instead of echoed",
+              fun _ ->
+                  let response =
+                      handleRequest server tools """{"jsonrpc":"2.0","id":{"unsafe":true},"method":"ping"}"""
+
+                  assertThat (errorCode response) (isEqualTo "-32600")
+                  assertThat (responseId response) (isEqualTo "null")
+          )
+
+          test ("malformed JSON is a parse error", fun _ -> assertThat (handleRequest server tools "{" |> errorCode) (isEqualTo "-32700"))
+
+          test (
+              "invalid request members produce Invalid Request",
+              fun _ ->
+                  assertThat
+                      (handleRequest server tools """{"jsonrpc":"1.0","id":1,"method":"ping"}"""
+                       |> errorCode)
+                      (isEqualTo "-32600")
+
+                  assertThat
+                      (handleRequest server tools """{"jsonrpc":"2.0","id":1,"method":7}"""
+                       |> errorCode)
+                      (isEqualTo "-32600")
+          )
+
+          test (
+              "unsupported protocol versions report negotiation data",
+              fun _ ->
+                  let json =
+                      handleRequest
+                          server
+                          tools
+                          """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2099-01-01","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}"""
+                      |> responseJson
+
+                  assertThat
+                      (json
+                       |> field "error"
+                       |> rawGet "code"
+                       |> rawToJson)
+                      (isEqualTo "-32602")
+
+                  assertThat
+                      (json
+                       |> field "error"
+                       |> rawGet "data"
+                       |> rawGet "requested"
+                       |> rawAsString)
+                      (isEqualTo "2099-01-01")
+          )
+
+          test (
+              "missing initialize parameters are rejected",
+              fun _ ->
+                  assertThat
+                      (handleRequest server tools """{"jsonrpc":"2.0","id":1,"method":"initialize"}"""
+                       |> errorCode)
+                      (isEqualTo "-32602")
+          )
+
+          test (
+              "unknown tools and malformed tool calls are Invalid params",
+              fun _ ->
+                  assertThat
+                      (handleRequest server tools """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"missing"}}"""
+                       |> errorCode)
+                      (isEqualTo "-32602")
+
+                  assertThat
+                      (handleRequest
+                          server
+                          tools
+                          """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":[]}}"""
+                       |> errorCode)
+                      (isEqualTo "-32602")
+          )
+
+          test (
+              "tool execution errors and JSON escaping are encoded as MCP results",
+              fun _ ->
+                  match handleRequest server tools """{"jsonrpc":"2.0","id":"tool","method":"tools/call","params":{"name":"echo"}}""" with
+                  | CallTool(id, _) ->
+                      let result =
+                          completeToolCall
+                              id
+                              { Content = "bad \"input\"\nnext"
+                                IsError = true }
+                          |> field "result"
+
+                      assertThat (result |> rawGet "isError" |> rawToJson) (isEqualTo "true")
+
+                      assertThat ((result |> rawGet "content" |> rawToJson).Contains("bad \\\"input\\\"\\nnext")) isTrue
+                  | other -> failwith $"Expected a tool call, got %A{other}"
+          )
+
+          test (
+              "notifications do not produce a JSON-RPC response",
+              fun _ ->
+                  assertThat
+                      (handleRequest server tools """{"jsonrpc":"2.0","method":"notifications/initialized"}""")
+                      (isEqualTo NoResponse)
+          )
+
+          test (
+              "batch requests are rejected",
+              fun _ ->
+                  let error =
+                      handleRequest server tools "[]"
+                      |> responseJson
+                      |> field "error"
+
+                  assertThat (error |> rawGet "code" |> rawToJson) (isEqualTo "-32600")
+          )
+
+          testAsync (
+              "streamable HTTP maps notifications to 202",
+              fun _ ->
+                  toAsync (
+                      task {
+                          let ctx, readBody = TestContext.create (method = "POST", body = "notification")
+                          let! result = streamableHttp (fun _ -> "") next ctx
+                          assertThat result.IsSome isTrue
+                          assertThat ctx.Response.StatusCode (isEqualTo 202)
+                          assertThat (readBody ()) (isEqualTo [||])
+                      }
+                  )
+          )
+
+          testAsync (
+              "streamable HTTP maps JSON-RPC responses to 200 application/json",
+              fun _ ->
+                  toAsync (
+                      task {
+                          let response = """{"jsonrpc":"2.0","id":1,"result":{}}"""
+                          let ctx, readBody = TestContext.create (method = "POST", body = "request")
+                          let! result = streamableHttp (fun _ -> response) next ctx
+                          assertThat result.IsSome isTrue
+                          assertThat ctx.Response.StatusCode (isEqualTo 200)
+                          assertThat (ctx.Response.Headers["content-type"]).[0] (isEqualTo "application/json")
+                          assertThat (Encoding.UTF8.GetString(readBody ())) (isEqualTo response)
+                      }
+                  )
+          ) ]
+    )


### PR DESCRIPTION
## Summary

- add a shared JSON-RPC/MCP core for initialization, ping, tool discovery, tool-call dispatch, notifications, protocol negotiation, and errors
- preserve scalar request IDs and arbitrary tool argument JSON across Python, JavaScript, and BEAM
- expose a synchronous Streamable HTTP POST/JSON handler while leaving execution, authentication, integrity, sessions, and timeout policy to applications
- compile and package Mcp.fs for every target and document the public boundary
- add shared cross-target coverage for malformed requests, IDs, unsupported versions, unknown tools, tool errors, escaping, and HTTP 200/202 behavior

## Verification

- just format
- just test-native
- just test-python (118 passed)
- just test-js (117 passed, 1 skipped)
- just test-beam (114 passed, 4 skipped)
- just pack
- inspected all three NuGet packages and confirmed fable/Mcp.fs is included
- git diff --check