### PR TITLE
feat: add typed MCP tool hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,40 @@ message; JSON-RPC batches are rejected. Lifecycle state enforcement is likewise
 left to a session-aware application—the core performs initialization negotiation
 but does not remember whether a client has sent `notifications/initialized`.
 
+Typed tool registration can derive the input schema and decode arguments without
+runtime attribute discovery:
+
+```fsharp
+type EchoInput = { Text: string }
+
+let tools = [
+    Mcp.Tools.defineSync "echo" (fun input ->
+        { Content = input.Text; IsError = false })
+    |> Mcp.Tools.description "Echo text"
+]
+
+let webApp =
+    POST
+    >=> route "/mcp"
+    >=> Mcp.Tools.host server tools
+```
+
+`define` accepts an asynchronous `EchoInput -> Async<Mcp.ToolResult>` function;
+`defineSync` is the synchronous convenience. Registration is explicit so function
+references, generic input types, schema generation and invocation remain portable
+under Fable. Decode failures become MCP tool errors, while unexpected application
+exceptions become a non-leaking JSON-RPC `Internal error`.
+
+The Python, JavaScript and BEAM example apps all compile
+[`app/McpExample.fs`](app/McpExample.fs) and expose its typed `greet` tool at
+`POST /mcp`. After starting any example, try it with:
+
+```console
+curl http://127.0.0.1:8080/mcp \
+  -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"greet","arguments":{"name":"Fable"}}}'
+```
+
 ## Prerequisites
 
 - .NET SDK 8+

--- a/README.md
+++ b/README.md
@@ -255,22 +255,23 @@ runtime attribute discovery:
 type EchoInput = { Text: string }
 
 let tools = [
-    Mcp.Tools.defineSync "echo" (fun input ->
-        { Content = input.Text; IsError = false })
-    |> Mcp.Tools.description "Echo text"
+    Mcp.Tools.tool "echo" (fun input -> Mcp.ToolResult.text input.Text)
+    |> Mcp.Tools.describe "Echo text"
 ]
 
 let webApp =
     POST
     >=> route "/mcp"
-    >=> Mcp.Tools.host server tools
+    >=> Mcp.Tools.handler server tools
 ```
 
-`define` accepts an asynchronous `EchoInput -> Async<Mcp.ToolResult>` function;
-`defineSync` is the synchronous convenience. Registration is explicit so function
-references, generic input types, schema generation and invocation remain portable
-under Fable. Decode failures become MCP tool errors, while unexpected application
-exceptions become a non-leaking JSON-RPC `Internal error`.
+`toolAsync` accepts an asynchronous `EchoInput -> Async<Mcp.ToolResult>` function.
+The lower-level names `define`, `defineSync`, `description`, and `host` remain
+available for compatibility and infrastructure-oriented code.
+Registration is explicit so function references, generic input types, schema
+generation and invocation remain portable under Fable. Decode failures become MCP
+tool errors, while unexpected application exceptions become a non-leaking JSON-RPC
+`Internal error`.
 
 The Python, JavaScript and BEAM example apps all compile
 [`app/McpExample.fs`](app/McpExample.fs) and expose its typed `greet` tool at

--- a/app/McpExample.fs
+++ b/app/McpExample.fs
@@ -1,0 +1,22 @@
+module McpExample
+
+open Fable.Giraffe
+open Fable.Giraffe.Mcp
+
+/// PascalCase fields produce the same camelCase MCP wire names on every Fable target.
+type GreetInput = { Name: string }
+
+let server =
+    { Info =
+        { Name = "fable-giraffe-example"
+          Version = "1.0.0" }
+      ProtocolVersions = [ "2025-11-25" ] }
+
+let tools =
+    [ Tools.defineSync "greet" (fun input ->
+          { Content = $"Hello, %s{input.Name}!"
+            IsError = false })
+      |> Tools.description "Greet someone by name" ]
+
+/// The same typed tool and Streamable HTTP handler run on Python, JavaScript and BEAM.
+let handler: HttpHandler = Tools.host server tools

--- a/app/McpExample.fs
+++ b/app/McpExample.fs
@@ -13,10 +13,8 @@ let server =
       ProtocolVersions = [ "2025-11-25" ] }
 
 let tools =
-    [ Tools.defineSync "greet" (fun input ->
-          { Content = $"Hello, %s{input.Name}!"
-            IsError = false })
-      |> Tools.description "Greet someone by name" ]
+    [ Tools.tool "greet" (fun input -> ToolResult.text $"Hello, %s{input.Name}!")
+      |> Tools.describe "Greet someone by name" ]
 
 /// The same typed tool and Streamable HTTP handler run on Python, JavaScript and BEAM.
-let handler: HttpHandler = Tools.host server tools
+let handler: HttpHandler = Tools.handler server tools

--- a/app/Program.fs
+++ b/app/Program.fs
@@ -44,7 +44,10 @@ let endpoints =
             |> summary "Greet someone"
             |> accepts<Model>
             |> respondsWith<string> 200 "text/plain"
-            |> respondsWith<string> 422 "application/json" ] ]
+            |> respondsWith<string> 422 "application/json"
+
+            // One typed MCP tool definition is shared by the Python, JavaScript and BEAM apps.
+            route "/mcp" McpExample.handler ] ]
 
 let webApp =
     endpoints

--- a/app/Program.fsproj
+++ b/app/Program.fsproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="public/index.html" />
+    <Compile Include="McpExample.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/app/beam/Program.fs
+++ b/app/beam/Program.fs
@@ -23,7 +23,10 @@ let endpoints =
           [ route "/greet" (validateJson<Model> (fun m -> text $"Hello, {m.Name}"))
             |> summary "Greet someone"
             |> accepts<Model>
-            |> respondsWith<string> 200 "text/plain" ] ]
+            |> respondsWith<string> 200 "text/plain"
+
+            // See app/McpExample.fs: no BEAM-specific tool mapping is required.
+            route "/mcp" McpExample.handler ] ]
 
 /// The OpenAPI document is rendered once here, at composition time, and the spec handler
 /// closes over the resulting string. That is what makes it work under Cowboy, which spawns a

--- a/app/beam/Program.fsproj
+++ b/app/beam/Program.fsproj
@@ -6,6 +6,7 @@
     <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\McpExample.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/app/js/Program.fs
+++ b/app/js/Program.fs
@@ -33,6 +33,8 @@ let webApp =
 
           route "/echo" >=> echo
 
+          POST >=> route "/mcp" >=> McpExample.handler
+
           route "/log" |> loggingHandler ]
 
 WebHostBuilder()

--- a/app/js/Program.fsproj
+++ b/app/js/Program.fsproj
@@ -6,6 +6,7 @@
     <WarnOn>3390;$(WarnOn)</WarnOn>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\McpExample.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Mcp.fs
+++ b/src/Mcp.fs
@@ -26,6 +26,15 @@ type ToolCall = { Name: string; ArgumentsJson: string }
 
 type ToolResult = { Content: string; IsError: bool }
 
+[<RequireQualifiedAccess>]
+module ToolResult =
+
+    /// A successful text result for the common MCP tool case.
+    let text (content: string) : ToolResult = { Content = content; IsError = false }
+
+    /// A text result that reports an application-level tool error to the caller.
+    let error (content: string) : ToolResult = { Content = content; IsError = true }
+
 type RequestId = private RequestId of obj
 
 type Action =
@@ -246,10 +255,7 @@ module Tools =
             async {
                 match tryDeserialize<'Input> argumentsJson with
                 | Ok arguments -> return! execute arguments
-                | Error _ ->
-                    return
-                        { Content = "Invalid tool arguments"
-                          IsError = true }
+                | Error _ -> return ToolResult.error "Invalid tool arguments"
             }
 
         defineCore name (schemaFor typeof<'Input>) invoke
@@ -257,12 +263,23 @@ module Tools =
     /// Define a synchronous tool without manually wrapping its result in `async`.
     let inline defineSync<'Input> (name: string) (execute: 'Input -> ToolResult) : ToolDefinition = define name (execute >> async.Return)
 
+    /// Define a synchronous typed tool. This is the concise application-facing
+    /// alias for `defineSync`.
+    let inline tool<'Input> (name: string) (execute: 'Input -> ToolResult) : ToolDefinition = defineSync name execute
+
+    /// Define an asynchronous typed tool. This is the concise application-facing
+    /// alias for `define`.
+    let inline toolAsync<'Input> (name: string) (execute: 'Input -> Async<ToolResult>) : ToolDefinition = define name execute
+
     /// Set the human-readable description returned by `tools/list`.
     let description (text: string) (definition: ToolDefinition) : ToolDefinition =
         { definition with
             ProtocolTool =
                 { definition.ProtocolTool with
                     Description = text } }
+
+    /// Set the human-readable description returned by `tools/list`.
+    let describe (text: string) (definition: ToolDefinition) : ToolDefinition = description text definition
 
     /// The protocol descriptions consumed by the transport-independent MCP core.
     let protocolTools (definitions: ToolDefinition list) : Tool list = definitions |> List.map _.ProtocolTool
@@ -307,6 +324,9 @@ module Tools =
     let host (server: Server) (definitions: ToolDefinition list) : HttpHandler =
         dispatcher server definitions
         |> streamableHttpAsync
+
+    /// Create a classic Giraffe handler for the typed tools.
+    let handler (server: Server) (definitions: ToolDefinition list) : HttpHandler = host server definitions
 
 /// The POST/JSON subset of Streamable HTTP for a synchronous MCP dispatcher.
 /// An empty result represents an accepted notification and is returned as HTTP 202.

--- a/src/Mcp.fs
+++ b/src/Mcp.fs
@@ -33,6 +33,14 @@ type Action =
     | Respond of string
     | CallTool of RequestId * ToolCall
 
+/// A typed tool registration with its protocol description and application executor.
+/// The executor accepts raw arguments so heterogeneous definitions can share one list;
+/// `Tools.define` restores the input type before invoking application code.
+type ToolDefinition =
+    private
+        { ProtocolTool: Tool
+          Execute: string -> Async<ToolResult> }
+
 let private str (value: string) : obj = box value
 let private boolValue (value: bool) : obj = box value
 let private intValue (value: int) : obj = box value
@@ -199,6 +207,106 @@ let completeToolCall (id: RequestId) (result: ToolResult) : string =
             [ "content", content ]
 
     buildResult id (rawObject fields |> rawToJson)
+
+/// The POST/JSON subset of Streamable HTTP for an asynchronous MCP dispatcher.
+/// `None` represents an accepted notification; `Some json` is a JSON-RPC response.
+let streamableHttpAsync (dispatch: string -> Async<string option>) : HttpHandler =
+    fun (_: HttpFunc) (ctx: HttpContext) ->
+        task {
+            let! body = ctx.ReadBodyFromRequestAsync()
+            let! result = dispatch body |> startAsTask
+
+            match result with
+            | None ->
+                ctx.SetStatusCode 202
+                return! ctx.WriteBytesAsync [||]
+            | Some json ->
+                ctx.SetStatusCode 200
+                ctx.SetContentType "application/json"
+                return! ctx.WriteBytesAsync(Encoding.UTF8.GetBytes json)
+        }
+
+/// Explicit, typed MCP tool registration. This is the Fable-portable counterpart
+/// to reflection/attribute-based registration in runtime-specific MCP SDKs.
+module Tools =
+
+    /// Compiler-facing constructor used by the inline typed builders.
+    [<System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)>]
+    let defineCore (name: string) (inputSchemaJson: string) (execute: string -> Async<ToolResult>) : ToolDefinition =
+        { ProtocolTool =
+            { Name = name
+              Description = ""
+              InputSchemaJson = inputSchemaJson }
+          Execute = execute }
+
+    /// Define an asynchronous tool. Its input schema and decoder come from the same
+    /// TypedJson type walk; note that TypedJson may coerce compatible primitives.
+    let inline define<'Input> (name: string) (execute: 'Input -> Async<ToolResult>) : ToolDefinition =
+        let invoke argumentsJson =
+            async {
+                match tryDeserialize<'Input> argumentsJson with
+                | Ok arguments -> return! execute arguments
+                | Error _ ->
+                    return
+                        { Content = "Invalid tool arguments"
+                          IsError = true }
+            }
+
+        defineCore name (schemaFor typeof<'Input>) invoke
+
+    /// Define a synchronous tool without manually wrapping its result in `async`.
+    let inline defineSync<'Input> (name: string) (execute: 'Input -> ToolResult) : ToolDefinition = define name (execute >> async.Return)
+
+    /// Set the human-readable description returned by `tools/list`.
+    let description (text: string) (definition: ToolDefinition) : ToolDefinition =
+        { definition with
+            ProtocolTool =
+                { definition.ProtocolTool with
+                    Description = text } }
+
+    /// The protocol descriptions consumed by the transport-independent MCP core.
+    let protocolTools (definitions: ToolDefinition list) : Tool list = definitions |> List.map _.ProtocolTool
+
+    let private validate (definitions: ToolDefinition list) =
+        let duplicate =
+            definitions
+            |> List.groupBy _.ProtocolTool.Name
+            |> List.tryFind (fun (_, definitions) -> List.length definitions > 1)
+
+        match duplicate with
+        | Some(name, _) -> invalidArg "definitions" $"Duplicate MCP tool name: %s{name}"
+        | None -> ()
+
+    /// Build an asynchronous dispatcher once at composition time. Protocol parsing
+    /// remains in `handleRequest`; only a `CallTool` action enters application code.
+    let dispatcher (server: Server) (definitions: ToolDefinition list) : string -> Async<string option> =
+        validate definitions
+        let tools = protocolTools definitions
+
+        fun body ->
+            async {
+                match handleRequest server tools body with
+                | NoResponse -> return None
+                | Respond response -> return Some response
+                | CallTool(id, call) ->
+                    let definition =
+                        definitions
+                        |> List.find (fun definition -> definition.ProtocolTool.Name = call.Name)
+
+                    let! outcome =
+                        definition.Execute call.ArgumentsJson
+                        |> Async.Catch
+
+                    match outcome with
+                    | Choice1Of2 result -> return Some(completeToolCall id result)
+                    | Choice2Of2 _ -> return Some(buildError id -32603 "Internal error")
+            }
+
+    /// Mount typed tools as the synchronous-response subset of Streamable HTTP.
+    /// Authentication, transport headers, sessions and timeouts remain composable policy.
+    let host (server: Server) (definitions: ToolDefinition list) : HttpHandler =
+        dispatcher server definitions
+        |> streamableHttpAsync
 
 /// The POST/JSON subset of Streamable HTTP for a synchronous MCP dispatcher.
 /// An empty result represents an accepted notification and is returned as HTTP 202.

--- a/src/beam/Json.fs
+++ b/src/beam/Json.fs
@@ -82,6 +82,11 @@ let inline tryDeserialize<'T> (s: string) : Result<'T, FieldError list> = (codec
 let renderJson (value: JsonSchemaValue) : string =
     Fable.TypedJson.JsonSchemaGen.schemaValueToJson beam value
 
+/// The inline JSON Schema for a reflected type. Protocol descriptions such as
+/// MCP tool input schemas need a self-contained schema rather than OpenAPI refs.
+let schemaFor (t: System.Type) : string =
+    Fable.TypedJson.JsonSchemaGen.schemaJsonFor beam emptyRegistry Map.empty CaseRules.LowerFirst t
+
 /// The `$ref`-mode JSON Schema for a reflected type: its own fragment (a `$ref`
 /// for any record or union) plus every type reached beneath it, keyed by name.
 ///

--- a/src/js/Json.fs
+++ b/src/js/Json.fs
@@ -82,6 +82,11 @@ let inline tryDeserialize<'T> (s: string) : Result<'T, FieldError list> = (codec
 let renderJson (value: JsonSchemaValue) : string =
     Fable.TypedJson.JsonSchemaGen.schemaValueToJson js value
 
+/// The inline JSON Schema for a reflected type. Protocol descriptions such as
+/// MCP tool input schemas need a self-contained schema rather than OpenAPI refs.
+let schemaFor (t: System.Type) : string =
+    Fable.TypedJson.JsonSchemaGen.schemaJsonFor js emptyRegistry Map.empty CaseRules.LowerFirst t
+
 /// The `$ref`-mode JSON Schema for a reflected type: its own fragment (a `$ref`
 /// for any record or union) plus every type reached beneath it, keyed by name.
 ///

--- a/src/python/Json.fs
+++ b/src/python/Json.fs
@@ -85,6 +85,11 @@ let inline tryDeserialize<'T> (s: string) : Result<'T, FieldError list> = (codec
 let renderJson (value: JsonSchemaValue) : string =
     Fable.TypedJson.JsonSchemaGen.schemaValueToJson python value
 
+/// The inline JSON Schema for a reflected type. Protocol descriptions such as
+/// MCP tool input schemas need a self-contained schema rather than OpenAPI refs.
+let schemaFor (t: System.Type) : string =
+    Fable.TypedJson.JsonSchemaGen.schemaJsonFor python emptyRegistry Map.empty CaseRules.LowerFirst t
+
 /// The `$ref`-mode JSON Schema for a reflected type: its own fragment (a `$ref`
 /// for any record or union) plus every type reached beneath it, keyed by name.
 ///

--- a/test/shared/McpTests.fs
+++ b/test/shared/McpTests.fs
@@ -19,6 +19,17 @@ let private tools =
         Description = "Echo text"
         InputSchemaJson = """{"type":"object","properties":{"text":{"type":"string"}},"required":["text"]}""" } ]
 
+type EchoInput = { Text: string }
+
+let private typedTools =
+    [ Tools.defineSync "echo" (fun input ->
+          { Content = input.Text
+            IsError = false })
+      |> Tools.description "Echo text"
+
+      Tools.defineSync "explode" (fun (_: EchoInput) -> failwith "application secret")
+      |> Tools.description "Throw an exception" ]
+
 let private responseJson =
     function
     | Respond json -> json
@@ -227,6 +238,71 @@ let tests =
                   assertThat (error |> rawGet "code" |> rawToJson) (isEqualTo "-32600")
           )
 
+          test (
+              "typed tool registration derives its protocol description and input schema",
+              fun _ ->
+                  let echo = Tools.protocolTools typedTools |> List.head
+                  assertThat echo.Name (isEqualTo "echo")
+                  assertThat echo.Description (isEqualTo "Echo text")
+
+                  let schema = deserialize echo.InputSchemaJson
+                  assertThat (schema |> rawGet "type" |> rawAsString) (isEqualTo "object")
+
+                  assertThat
+                      (schema
+                       |> rawGet "properties"
+                       |> rawGet "text"
+                       |> rawGet "type"
+                       |> rawAsString)
+                      (isEqualTo "string")
+          )
+
+          testAsync (
+              "typed dispatcher decodes arguments and executes application code",
+              fun _ ->
+                  async {
+                      let! response =
+                          Tools.dispatcher
+                              server
+                              typedTools
+                              """{"jsonrpc":"2.0","id":"typed","method":"tools/call","params":{"name":"echo","arguments":{"text":"hello"}}}"""
+
+                      let result = response |> Option.get |> field "result"
+                      assertThat ((result |> rawGet "content" |> rawToJson).Contains("hello")) isTrue
+                  }
+          )
+
+          testAsync (
+              "typed dispatcher reports decoding failures as tool errors",
+              fun _ ->
+                  async {
+                      let! response =
+                          Tools.dispatcher
+                              server
+                              typedTools
+                              """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{}}}"""
+
+                      let result = response |> Option.get |> field "result"
+                      assertThat (result |> rawGet "isError" |> rawToJson) (isEqualTo "true")
+                  }
+          )
+
+          testAsync (
+              "typed dispatcher hides application exceptions behind Internal error",
+              fun _ ->
+                  async {
+                      let! response =
+                          Tools.dispatcher
+                              server
+                              typedTools
+                              """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"explode","arguments":{"text":"boom"}}}"""
+
+                      let error = response |> Option.get |> field "error"
+                      assertThat (error |> rawGet "code" |> rawToJson) (isEqualTo "-32603")
+                      assertThat ((error |> rawGet "message" |> rawAsString).Contains("secret")) isFalse
+                  }
+          )
+
           testAsync (
               "streamable HTTP maps notifications to 202",
               fun _ ->
@@ -253,6 +329,24 @@ let tests =
                           assertThat ctx.Response.StatusCode (isEqualTo 200)
                           assertThat (ctx.Response.Headers["content-type"]).[0] (isEqualTo "application/json")
                           assertThat (Encoding.UTF8.GetString(readBody ())) (isEqualTo response)
+                      }
+                  )
+          )
+
+          testAsync (
+              "typed tools mount as an asynchronous Giraffe handler",
+              fun _ ->
+                  toAsync (
+                      task {
+                          let request =
+                              """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hosted"}}}"""
+
+                          let ctx, readBody = TestContext.create (method = "POST", body = request)
+                          let! result = Tools.host server typedTools next ctx
+                          assertThat result.IsSome isTrue
+                          assertThat ctx.Response.StatusCode (isEqualTo 200)
+
+                          assertThat ((Encoding.UTF8.GetString(readBody ())).Contains("hosted")) isTrue
                       }
                   )
           ) ]

--- a/test/shared/McpTests.fs
+++ b/test/shared/McpTests.fs
@@ -22,13 +22,11 @@ let private tools =
 type EchoInput = { Text: string }
 
 let private typedTools =
-    [ Tools.defineSync "echo" (fun input ->
-          { Content = input.Text
-            IsError = false })
-      |> Tools.description "Echo text"
+    [ Tools.tool "echo" (fun input -> ToolResult.text input.Text)
+      |> Tools.describe "Echo text"
 
-      Tools.defineSync "explode" (fun (_: EchoInput) -> failwith "application secret")
-      |> Tools.description "Throw an exception" ]
+      Tools.toolAsync "explode" (fun (_: EchoInput) -> async { return failwith "application secret" })
+      |> Tools.describe "Throw an exception" ]
 
 let private responseJson =
     function
@@ -239,6 +237,13 @@ let tests =
           )
 
           test (
+              "tool result helpers construct success and error results",
+              fun _ ->
+                  assertThat (ToolResult.text "ok") (isEqualTo { Content = "ok"; IsError = false })
+                  assertThat (ToolResult.error "no") (isEqualTo { Content = "no"; IsError = true })
+          )
+
+          test (
               "typed tool registration derives its protocol description and input schema",
               fun _ ->
                   let echo = Tools.protocolTools typedTools |> List.head
@@ -342,7 +347,7 @@ let tests =
                               """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"echo","arguments":{"text":"hosted"}}}"""
 
                           let ctx, readBody = TestContext.create (method = "POST", body = request)
-                          let! result = Tools.host server typedTools next ctx
+                          let! result = Tools.handler server typedTools next ctx
                           assertThat result.IsSome isTrue
                           assertThat ctx.Response.StatusCode (isEqualTo 200)
 


### PR DESCRIPTION
## Summary

- add portable typed MCP tool definitions with derived input schemas and argument decoding
- provide concise tool, toolAsync, describe, and handler APIs plus ToolResult text/error helpers
- add async dispatch and Streamable HTTP hosting with safe error handling
- share a typed MCP example across Python, JavaScript, and BEAM apps
- document the API and cover it in the cross-target MCP suite

## Validation

- just format
- just test-native
- just test-python
- just test-js
- just test-beam
- compiled all three example apps with their Fable backends