### PR TITLE
fix(deps): upgrade Beam and TypedJson

### DIFF
--- a/src/Fable.Giraffe.Beam.fsproj
+++ b/src/Fable.Giraffe.Beam.fsproj
@@ -50,13 +50,10 @@
          Fable.TypedJson requires, which NU1605 reports as a downgrade. -->
     <PackageReference Update="FSharp.Core" Version="11.0.100" />
     <PackageReference Include="Fable.Core" Version="5.2.0" />
-    <!-- Core is 5.0.1 (the $ref-collision and date-parsing fixes); the backend
-         shims are unchanged since 5.0.0 and were not rebuilt. They resolve
-         against whichever core NuGet picks, which is the 5.0.1 requested here. -->
-    <PackageReference Include="Fable.TypedJson" Version="5.1.0" />
-    <PackageReference Include="Fable.TypedJson.Beam" Version="5.1.0" />
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.36" />
-    <PackageReference Include="Fable.Beam.Jsx" Version="5.0.0-rc.8" />
+    <PackageReference Include="Fable.TypedJson" Version="5.3.0" />
+    <PackageReference Include="Fable.TypedJson.Beam" Version="5.3.0" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.37" />
+    <PackageReference Include="Fable.Beam.Jsx" Version="5.0.0-rc.9" />
     <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.24" />
     <PackageReference Include="Fable.Logging" Version="1.0.0" />
     <PackageReference Include="Fable.Logging.Beam" Version="1.0.0" />

--- a/src/beam/HttpContext.fs
+++ b/src/beam/HttpContext.fs
@@ -35,7 +35,7 @@ type HttpRequest(req: Req) =
     /// Cowboy is the normalising layer here — a client's `Authorization` arrives as
     /// `authorization`, and repeated headers are folded into a single comma-joined value — so
     /// this is a plain map read rather than a reimplementation of header semantics.
-    member private x.HeaderPairs = Maps.maps.to_list (CowboyReq.headers req)
+    member private x.HeaderPairs = Maps.toArray (CowboyReq.headers req)
 
     member x.GetTypedHeaders() : RequestHeaders =
         // RequestHeaders reads rows of [name; value; ...], the same shape the Python/ASGI

--- a/test/beam/Fable.Giraffe.Tests.Beam.fsproj
+++ b/test/beam/Fable.Giraffe.Tests.Beam.fsproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Fable.Core" Version="5.2.0" />
     <PackageReference Include="Scriptorium.Quill" Version="0.5.1" />
     <PackageReference Include="Scriptorium.Nib" Version="0.4.1" />
-    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.34" />
+    <PackageReference Include="Fable.Beam" Version="5.0.0-rc.37" />
     <PackageReference Include="Fable.Beam.Cowboy" Version="5.0.0-rc.24" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- upgrade Fable.Beam to 5.0.0-rc.37 and Fable.Beam.Jsx to rc.9
- upgrade Fable.TypedJson and Fable.TypedJson.Beam to 5.3.0
- adapt request-header map conversion to the rc.37 Maps API

## Validation
- just test-beam (120 passed, 4 skipped)
- git diff --check