### PR TITLE
chore: force v5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 last_commit_released: 0a5c8e8cec66102ddd569b950cc840734fe1d9be
 name: Fable.Giraffe
+force_version: 5.0.0
 ---
 
 # Changelog


### PR DESCRIPTION
## Summary
- force the next ShipIt release to version 5.0.0
- retain the Fable v5 release line after the Beam and TypedJson dependency upgrade

## Validation
- just shipit --mode local --dry-run --allow-branch chore/force-v5-release
  - reports Fable.Giraffe 5.0.0
  - previews chore: release Fable.Giraffe@5.0.0