### PR TITLE
chore: force v5.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ---
 last_commit_released: 7ee28b23b8f3de5f6c434a20d837e1afa1da15a1
 name: Fable.Giraffe
+force_version: 5.5.0
 ---
 
 # Changelog


### PR DESCRIPTION
## Summary
- force the next ShipIt release to version 5.5.0
- correct the earlier 5.0.0 force_version after identifying the old package is no longer used

## Validation
- just shipit --mode local --dry-run --allow-branch chore/force-v5-5-release-next
  - reports Fable.Giraffe 5.5.0
  - previews chore: release Fable.Giraffe@5.5.0